### PR TITLE
SliceRequest 의 size 자료형 long -> int 로 변경

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/global/common/dto/SliceRequest.java
+++ b/src/main/java/com/ndgl/spotfinder/global/common/dto/SliceRequest.java
@@ -8,6 +8,6 @@ public record SliceRequest(
 	long lastId,
 
 	@Positive(message = "요청 Slice 사이즈는 양수여야 합니다.")
-	long size
+	int size
 ) {
 }


### PR DESCRIPTION
이유 : Pageable.of() 의 인자로 int형을 받는다.