### PR TITLE
fix : https 자격증명 대응 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM openjdk:17
 LABEL authors="nrkim"
 
-
-
-# keystore.p12 복사 추가
-COPY src/main/resources/keystore.p12 /app/keystore.p12
-
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 


### PR DESCRIPTION
Docker file 

Spring boot에서 더이상 Keystore 이용 안하므로 

# keystore.p12 복사 추가
COPY src/main/resources/keystore.p12 /app/keystore.p12 

삭제 