### PR TITLE
Fix/script

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
+++ b/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
@@ -88,6 +88,8 @@ public class SecurityConfig {
 					"/v3/api-docs/**"
 				)
 				.permitAll()
+				.requestMatchers(HttpMethod.OPTIONS, "/**")// 프리 플라이트 설정 추가 :
+				.permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/posts/**")
 				.permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments")

--- a/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
+++ b/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
@@ -88,7 +88,7 @@ public class SecurityConfig {
 					"/v3/api-docs/**"
 				)
 				.permitAll()
-				.requestMatchers(HttpMethod.OPTIONS, "/**")// 프리 플라이트 설정 추가 :
+				.requestMatchers(HttpMethod.OPTIONS, "/**")// Preflight 요청(CORS)을 허용하여 브라우저의 사전 요청 차단 문제 해결
 				.permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/posts/**")
 				.permitAll()


### PR DESCRIPTION
Security Config 수정 사항. 
- HttpMethod.OPTIONS 설정 추가 
  -  CORS의 정책 중 Preflight 정책이 존재하는데, 이 정책을 충족 시키기 위해서는 OPTION 메서드로 브라우저가 실데이터 전송 전에 서버에 요청을 보내도 되는지? 확인할 필요가 있음. 그렇기 때문에 Spring Security에 아래 두 구문 추가 

