### PR TITLE
포스트 조회 시 좋아요 개수 및 댓글 개수 포함 및 조회 쿼리 수 최적화

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/like/service/LikeService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/like/service/LikeService.java
@@ -153,7 +153,6 @@ public class LikeService {
 	 * 좋아요 삭제 및 대상 좋아요 카운트 감소
 	 */
 	private void deleteLike(Like like, long targetId, TargetType targetType) {
-		System.out.println("좋아요 수가 감소합니다." + targetId);
 		updateTargetLikeCount(targetId, targetType, -1);
 		likeRepository.delete(like);
 	}
@@ -162,7 +161,6 @@ public class LikeService {
 	 * 좋아요 생성 및 대상 좋아요 카운트 증가
 	 */
 	private void createLike(long userId, long targetId, TargetType targetType) {
-		System.out.println("좋아요 수가 증가합니다." + targetId);
 		User user = userService.findUserById(userId);
 		Like like = builder()
 			.user(user)

--- a/src/main/java/com/ndgl/spotfinder/domain/like/service/LikeService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/like/service/LikeService.java
@@ -153,6 +153,7 @@ public class LikeService {
 	 * 좋아요 삭제 및 대상 좋아요 카운트 감소
 	 */
 	private void deleteLike(Like like, long targetId, TargetType targetType) {
+		System.out.println("좋아요 수가 감소합니다." + targetId);
 		updateTargetLikeCount(targetId, targetType, -1);
 		likeRepository.delete(like);
 	}
@@ -161,6 +162,7 @@ public class LikeService {
 	 * 좋아요 생성 및 대상 좋아요 카운트 증가
 	 */
 	private void createLike(long userId, long targetId, TargetType targetType) {
+		System.out.println("좋아요 수가 증가합니다." + targetId);
 		User user = userService.findUserById(userId);
 		Like like = builder()
 			.user(user)
@@ -179,11 +181,11 @@ public class LikeService {
 		switch (targetType) {
 			case POST -> {
 				Post post = postService.findPostById(targetId);
-				post.updateLikeCount(post.getLikeCount() + num);
+				post.updateLikeCount(num);
 			}
 			case COMMENT -> {
 				PostComment comment = postCommentService.findById(targetId);
-				comment.updateLikeCount(comment.getLikeCount() + num);
+				comment.updateLikeCount(num);
 			}
 			default -> ErrorCode.UNSUPPORTED_TARGET_TYPE.throwServiceException();
 		}

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostDetailResponseDto.java
@@ -27,7 +27,7 @@ public record PostDetailResponseDto(
 	Long likeCount,
 
 	@Schema(description = "댓글 수", example = "72")
-	Long commentCount,
+	Integer commentCount,
 
 	@Schema(description = "작성 일자", example = "2025-03-23T14:30:00")
 	LocalDateTime createdAt,
@@ -46,7 +46,7 @@ public record PostDetailResponseDto(
 			post.getUser().getNickName(),
 			post.getThumbnail(),
 			post.getLikeCount(),
-			0L,
+			post.getComments().size(),
 			post.getCreatedAt(),
 			post.getHashtags()
 				.stream()

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
@@ -27,7 +27,7 @@ public record PostResponseDto(
 	Long likeCount,
 
 	@Schema(description = "댓글 수", example = "72")
-	Long commentCount,
+	Integer commentCount,
 
 	@Schema(description = "작성 일자", example = "2025-03-23T14:30:00")
 	LocalDateTime createdAt,
@@ -43,7 +43,7 @@ public record PostResponseDto(
 			post.getUser().getNickName(),
 			post.getThumbnail(),
 			post.getLikeCount(),
-			0L,
+			post.getComments().size(),
 			post.getCreatedAt(),
 			post.getHashtags()
 				.stream()

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
@@ -16,6 +16,7 @@ import com.ndgl.spotfinder.global.base.BaseTime;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -46,7 +47,7 @@ public class Post extends BaseTime {
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.data.annotation.LastModifiedDate;
 
+import com.ndgl.spotfinder.domain.comment.entity.PostComment;
 import com.ndgl.spotfinder.domain.post.dto.HashtagDto;
 import com.ndgl.spotfinder.domain.post.dto.LocationDto;
 import com.ndgl.spotfinder.domain.post.dto.PostUpdateRequestDto;
@@ -56,6 +57,10 @@ public class Post extends BaseTime {
 
 	@Builder.Default
 	private Long likeCount = 0L;
+
+	@Builder.Default
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostComment> comments = new ArrayList<>();
 
 	@Builder.Default
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,14 +13,17 @@ import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.user.entity.User;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findByIdLessThanOrderByCreatedAtDesc(Long lastId, PageRequest pageRequest);
 
+	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findByUserAndIdLessThanOrderByCreatedAtDesc(User user, Long lastId, PageRequest pageRequest);
 
 	@Query("SELECT p FROM Post p " +
 		   "JOIN Like l ON p.id = l.targetId AND l.targetType = 'POST' " +
 		   "WHERE l.user.id = :userId AND p.id < :lastId " +
 		   "ORDER BY p.createdAt DESC")
+	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findLikedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
 		PageRequest pageRequest);
 

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -12,7 +12,7 @@ import com.ndgl.spotfinder.domain.post.dto.PostUpdateRequestDto;
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.repository.PostRepository;
 import com.ndgl.spotfinder.domain.user.entity.User;
-import com.ndgl.spotfinder.domain.user.repository.UserRepository;
+import com.ndgl.spotfinder.domain.user.service.UserService;
 import com.ndgl.spotfinder.global.common.dto.SliceRequest;
 import com.ndgl.spotfinder.global.common.dto.SliceResponse;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
@@ -22,13 +22,12 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PostService {
-	private final UserRepository userRepository;
 	private final PostRepository postRepository;
+	private final UserService userService;
 
 	@Transactional
 	public void createPost(PostCreateRequestDto requestDto, String email) {
-		User user = userRepository.findByEmail(email)
-			.orElseThrow(ErrorCode.USER_NOT_FOUND::throwServiceException);
+		User user = userService.findUserByEmail(email);
 
 		postRepository.save(requestDto.toPost(user));
 	}
@@ -61,8 +60,7 @@ public class PostService {
 	public SliceResponse<PostResponseDto> getPostsByUser(SliceRequest sliceRequest, Long userId) {
 		PageRequest pageRequest = PageRequest.of(0, sliceRequest.size());
 		Long lastId = getLastPostId(sliceRequest);
-		User user = userRepository.findById(userId)
-			.orElseThrow(ErrorCode.USER_NOT_FOUND::throwServiceException);
+		User user = userService.findUserById(userId);
 
 		Slice<Post> results = postRepository.findByUserAndIdLessThanOrderByCreatedAtDesc(user, lastId, pageRequest);
 
@@ -78,8 +76,7 @@ public class PostService {
 	public SliceResponse<PostResponseDto> getPostsByLike(SliceRequest sliceRequest, String email) {
 		PageRequest pageRequest = PageRequest.of(0, sliceRequest.size());
 		Long lastId = getLastPostId(sliceRequest);
-		User user = userRepository.findByEmail(email)
-			.orElseThrow(ErrorCode.USER_NOT_FOUND::throwServiceException);
+		User user = userService.findUserByEmail(email);
 
 		Slice<Post> results = postRepository.findLikedPostsByUser(user.getId(), lastId, pageRequest);
 

--- a/src/test/java/com/ndgl/spotfinder/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/like/service/LikeServiceTest.java
@@ -12,17 +12,17 @@ import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.ndgl.spotfinder.domain.comment.entity.PostComment;
 import com.ndgl.spotfinder.domain.comment.service.PostCommentService;
 import com.ndgl.spotfinder.domain.like.entity.Like;
 import com.ndgl.spotfinder.domain.like.entity.Like.TargetType;
 import com.ndgl.spotfinder.domain.like.repository.LikeRepository;
+import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.service.PostService;
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.domain.user.repository.UserRepository;
 import com.ndgl.spotfinder.domain.user.service.UserService;
 import com.ndgl.spotfinder.global.exception.ServiceException;
-import com.ndgl.spotfinder.domain.post.entity.Post;
-import com.ndgl.spotfinder.domain.comment.entity.PostComment;
 
 /**
  * @see LikeService
@@ -30,294 +30,294 @@ import com.ndgl.spotfinder.domain.comment.entity.PostComment;
 @ActiveProfiles("test")
 @SpringBootTest
 public class LikeServiceTest {
-    @InjectMocks
-    private LikeService likeService;
+	@InjectMocks
+	private LikeService likeService;
 
-    @Mock
-    private LikeRepository likeRepository;
+	@Mock
+	private LikeRepository likeRepository;
 
-    @Mock
-    private UserService userService;
+	@Mock
+	private UserService userService;
 
-    @Mock
-    private PostService postService;
+	@Mock
+	private PostService postService;
 
-    @Mock
-    private PostCommentService postCommentService;
+	@Mock
+	private PostCommentService postCommentService;
 
-    @Mock
-    private UserRepository userRepository;
+	@Mock
+	private UserRepository userRepository;
 
-    private final User testUser = User.builder()
-            .id(1L)
-            .email("test@example.com")
-            .nickName("테스트유저")
-            .blogName("테스트블로그")
-            .build();
+	private final User testUser = User.builder()
+		.id(1L)
+		.email("test@example.com")
+		.nickName("테스트유저")
+		.blogName("테스트블로그")
+		.build();
 
-    private final Like postLike = Like.builder()
-            .id(1L)
-            .user(testUser)
-            .targetId(10L)
-            .targetType(TargetType.POST)
-            .build();
+	private final Like postLike = Like.builder()
+		.id(1L)
+		.user(testUser)
+		.targetId(10L)
+		.targetType(TargetType.POST)
+		.build();
 
-    private final Like commentLike = Like.builder()
-            .id(2L)
-            .user(testUser)
-            .targetId(20L)
-            .targetType(TargetType.COMMENT)
-            .build();
+	private final Like commentLike = Like.builder()
+		.id(2L)
+		.user(testUser)
+		.targetId(20L)
+		.targetType(TargetType.COMMENT)
+		.build();
 
-    @Test
-    @DisplayName("포스트 좋아요 추가 성공")
-    public void togglePostLike_add_success() {
-        // given
-        long userId = 1L;
-        long postId = 10L;
-        Post post = mock(Post.class);
-        when(post.getLikeCount()).thenReturn(0L);
+	@Test
+	@DisplayName("포스트 좋아요 추가 성공")
+	public void togglePostLike_add_success() {
+		// given
+		long userId = 1L;
+		long postId = 10L;
+		Post post = mock(Post.class);
+		when(post.getLikeCount()).thenReturn(0L);
 
-        // when
-        when(userService.findUserById(userId)).thenReturn(testUser);
-        when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
-                .thenReturn(Optional.empty());
-        when(postService.findPostById(postId)).thenReturn(post);
-        when(likeRepository.save(any(Like.class))).thenReturn(postLike);
+		// when
+		when(userService.findUserById(userId)).thenReturn(testUser);
+		when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
+			.thenReturn(Optional.empty());
+		when(postService.findPostById(postId)).thenReturn(post);
+		when(likeRepository.save(any(Like.class))).thenReturn(postLike);
 
-        boolean result = likeService.togglePostLike(userId, postId);
+		boolean result = likeService.togglePostLike(userId, postId);
 
-        // then
-        assertTrue(result);
-        verify(likeRepository).save(any(Like.class));
-        verify(post).updateLikeCount(1L);
-    }
+		// then
+		assertTrue(result);
+		verify(likeRepository).save(any(Like.class));
+		verify(post).updateLikeCount(1L);
+	}
 
-    @Test
-    @DisplayName("포스트 좋아요 취소 성공")
-    public void togglePostLike_remove_success() {
-        // given
-        long userId = 1L;
-        long postId = 10L;
-        Post post = mock(Post.class);
-        when(post.getLikeCount()).thenReturn(1L);
+	@Test
+	@DisplayName("포스트 좋아요 취소 성공")
+	public void togglePostLike_remove_success() {
+		// given
+		long userId = 1L;
+		long postId = 10L;
+		Post post = mock(Post.class);
+		when(post.getLikeCount()).thenReturn(1L);
 
-        // when
-        when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
-                .thenReturn(Optional.of(postLike));
-        when(postService.findPostById(postId)).thenReturn(post);
+		// when
+		when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
+			.thenReturn(Optional.of(postLike));
+		when(postService.findPostById(postId)).thenReturn(post);
 
-        boolean result = likeService.togglePostLike(userId, postId);
+		boolean result = likeService.togglePostLike(userId, postId);
 
-        // then
-        assertFalse(result);
-        verify(likeRepository).delete(postLike);
-        verify(post).updateLikeCount(0L);
-    }
+		// then
+		assertFalse(result);
+		verify(likeRepository).delete(postLike);
+		verify(post).updateLikeCount(-1);
+	}
 
-    @Test
-    @DisplayName("댓글 좋아요 추가 성공")
-    public void toggleCommentLike_add_success() {
-        // given
-        long userId = 1L;
-        long commentId = 20L;
-        PostComment comment = mock(PostComment.class);
-        when(comment.getLikeCount()).thenReturn(0L);
+	@Test
+	@DisplayName("댓글 좋아요 추가 성공")
+	public void toggleCommentLike_add_success() {
+		// given
+		long userId = 1L;
+		long commentId = 20L;
+		PostComment comment = mock(PostComment.class);
+		when(comment.getLikeCount()).thenReturn(0L);
 
-        // when
-        when(userService.findUserById(userId)).thenReturn(testUser);
-        when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
-                .thenReturn(Optional.empty());
-        when(postCommentService.findById(commentId)).thenReturn(comment);
-        when(likeRepository.save(any(Like.class))).thenReturn(commentLike);
+		// when
+		when(userService.findUserById(userId)).thenReturn(testUser);
+		when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
+			.thenReturn(Optional.empty());
+		when(postCommentService.findById(commentId)).thenReturn(comment);
+		when(likeRepository.save(any(Like.class))).thenReturn(commentLike);
 
-        boolean result = likeService.toggleCommentLike(userId, commentId);
+		boolean result = likeService.toggleCommentLike(userId, commentId);
 
-        // then
-        assertTrue(result);
-        verify(likeRepository).save(any(Like.class));
-        verify(comment).updateLikeCount(1L);
-    }
+		// then
+		assertTrue(result);
+		verify(likeRepository).save(any(Like.class));
+		verify(comment).updateLikeCount(1L);
+	}
 
-    @Test
-    @DisplayName("댓글 좋아요 취소 성공")
-    public void toggleCommentLike_remove_success() {
-        // given
-        long userId = 1L;
-        long commentId = 20L;
-        PostComment comment = mock(PostComment.class);
-        when(comment.getLikeCount()).thenReturn(1L);
+	@Test
+	@DisplayName("댓글 좋아요 취소 성공")
+	public void toggleCommentLike_remove_success() {
+		// given
+		long userId = 1L;
+		long commentId = 20L;
+		PostComment comment = mock(PostComment.class);
+		when(comment.getLikeCount()).thenReturn(1L);
 
-        // when
-        when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
-                .thenReturn(Optional.of(commentLike));
-        when(postCommentService.findById(commentId)).thenReturn(comment);
+		// when
+		when(likeRepository.findByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
+			.thenReturn(Optional.of(commentLike));
+		when(postCommentService.findById(commentId)).thenReturn(comment);
 
-        boolean result = likeService.toggleCommentLike(userId, commentId);
+		boolean result = likeService.toggleCommentLike(userId, commentId);
 
-        // then
-        assertFalse(result);
-        verify(likeRepository).delete(commentLike);
-        verify(comment).updateLikeCount(0L);
-    }
+		// then
+		assertFalse(result);
+		verify(likeRepository).delete(commentLike);
+		verify(comment).updateLikeCount(-1);
+	}
 
-    @Test
-    @DisplayName("좋아요 추가 실패 - 잘못된 타겟 ID")
-    public void toggleLike_invalidTargetId() {
-        // given
-        long userId = 1L;
-        long invalidTargetId = -1L;
-        
-        // then
-        ServiceException exception = assertThrows(ServiceException.class,
-                () -> likeService.togglePostLike(userId, invalidTargetId));
-        assertNotNull(exception);
-    }
+	@Test
+	@DisplayName("좋아요 추가 실패 - 잘못된 타겟 ID")
+	public void toggleLike_invalidTargetId() {
+		// given
+		long userId = 1L;
+		long invalidTargetId = -1L;
 
-    @Test
-    @DisplayName("포스트의 모든 좋아요 삭제 성공")
-    public void deleteAllLikesForPost_success() {
-        // given
-        long postId = 10L;
+		// then
+		ServiceException exception = assertThrows(ServiceException.class,
+			() -> likeService.togglePostLike(userId, invalidTargetId));
+		assertNotNull(exception);
+	}
 
-        // when
-        likeService.deleteAllLikesForPost(postId);
+	@Test
+	@DisplayName("포스트의 모든 좋아요 삭제 성공")
+	public void deleteAllLikesForPost_success() {
+		// given
+		long postId = 10L;
 
-        // then
-        verify(likeRepository).deleteByTargetIdAndTargetType(postId, TargetType.POST);
-    }
+		// when
+		likeService.deleteAllLikesForPost(postId);
 
-    @Test
-    @DisplayName("댓글의 모든 좋아요 삭제 성공")
-    public void deleteAllLikesForComment_success() {
-        // given
-        long commentId = 20L;
+		// then
+		verify(likeRepository).deleteByTargetIdAndTargetType(postId, TargetType.POST);
+	}
 
-        // when
-        likeService.deleteAllLikesForComment(commentId);
+	@Test
+	@DisplayName("댓글의 모든 좋아요 삭제 성공")
+	public void deleteAllLikesForComment_success() {
+		// given
+		long commentId = 20L;
 
-        // then
-        verify(likeRepository).deleteByTargetIdAndTargetType(commentId, TargetType.COMMENT);
-    }
+		// when
+		likeService.deleteAllLikesForComment(commentId);
 
-    @Test
-    @DisplayName("포스트 좋아요 수 조회 성공")
-    public void getPostLikeCount_success() {
-        // given
-        long postId = 10L;
-        long expectedCount = 5L;
-        
-        // when
-        when(likeRepository.countByTargetIdAndTargetType(postId, TargetType.POST))
-                .thenReturn(expectedCount);
-                
-        Long result = likeService.getPostLikeCount(postId);
-        
-        // then
-        assertEquals(expectedCount, result);
-        verify(likeRepository).countByTargetIdAndTargetType(postId, TargetType.POST);
-    }
-    
-    @Test
-    @DisplayName("댓글 좋아요 수 조회 성공")
-    public void getCommentLikeCount_success() {
-        // given
-        long commentId = 20L;
-        long expectedCount = 3L;
-        
-        // when
-        when(likeRepository.countByTargetIdAndTargetType(commentId, TargetType.COMMENT))
-                .thenReturn(expectedCount);
-                
-        Long result = likeService.getCommentLikeCount(commentId);
-        
-        // then
-        assertEquals(expectedCount, result);
-        verify(likeRepository).countByTargetIdAndTargetType(commentId, TargetType.COMMENT);
-    }
-    
-    @Test
-    @DisplayName("좋아요 수 조회 - 존재하지 않는 ID")
-    public void getLikeCount_invalidTargetId() {
-        // given
-        long invalidTargetId = -1L;
-        
-        // then
-        ServiceException exception = assertThrows(ServiceException.class,
-                () -> likeService.getPostLikeCount(invalidTargetId));
-        assertNotNull(exception);
-    }
-    
-    @Test
-    @DisplayName("포스트 좋아요 상태 조회 - 좋아요 있음")
-    public void getPostLikeStatus_exists() {
-        // given
-        long userId = 1L;
-        long postId = 10L;
-        
-        // when
-        when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
-                .thenReturn(true);
-                
-        Boolean result = likeService.getPostLikeStatus(userId, postId);
-        
-        // then
-        assertTrue(result);
-        verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST);
-    }
-    
-    @Test
-    @DisplayName("포스트 좋아요 상태 조회 - 좋아요 없음")
-    public void getPostLikeStatus_notExists() {
-        // given
-        long userId = 1L;
-        long postId = 10L;
-        
-        // when
-        when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
-                .thenReturn(false);
-                
-        Boolean result = likeService.getPostLikeStatus(userId, postId);
-        
-        // then
-        assertFalse(result);
-        verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST);
-    }
-    
-    @Test
-    @DisplayName("댓글 좋아요 상태 조회 - 좋아요 있음")
-    public void getCommentLikeStatus_exists() {
-        // given
-        long userId = 1L;
-        long commentId = 20L;
-        
-        // when
-        when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
-                .thenReturn(true);
-                
-        Boolean result = likeService.getCommentLikeStatus(userId, commentId);
-        
-        // then
-        assertTrue(result);
-        verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT);
-    }
-    
-    @Test
-    @DisplayName("댓글 좋아요 상태 조회 - 좋아요 없음")
-    public void getCommentLikeStatus_notExists() {
-        // given
-        long userId = 1L;
-        long commentId = 20L;
-        
-        // when
-        when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
-                .thenReturn(false);
-                
-        Boolean result = likeService.getCommentLikeStatus(userId, commentId);
-        
-        // then
-        assertFalse(result);
-        verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT);
-    }
+		// then
+		verify(likeRepository).deleteByTargetIdAndTargetType(commentId, TargetType.COMMENT);
+	}
 
-} 
+	@Test
+	@DisplayName("포스트 좋아요 수 조회 성공")
+	public void getPostLikeCount_success() {
+		// given
+		long postId = 10L;
+		long expectedCount = 5L;
+
+		// when
+		when(likeRepository.countByTargetIdAndTargetType(postId, TargetType.POST))
+			.thenReturn(expectedCount);
+
+		Long result = likeService.getPostLikeCount(postId);
+
+		// then
+		assertEquals(expectedCount, result);
+		verify(likeRepository).countByTargetIdAndTargetType(postId, TargetType.POST);
+	}
+
+	@Test
+	@DisplayName("댓글 좋아요 수 조회 성공")
+	public void getCommentLikeCount_success() {
+		// given
+		long commentId = 20L;
+		long expectedCount = 3L;
+
+		// when
+		when(likeRepository.countByTargetIdAndTargetType(commentId, TargetType.COMMENT))
+			.thenReturn(expectedCount);
+
+		Long result = likeService.getCommentLikeCount(commentId);
+
+		// then
+		assertEquals(expectedCount, result);
+		verify(likeRepository).countByTargetIdAndTargetType(commentId, TargetType.COMMENT);
+	}
+
+	@Test
+	@DisplayName("좋아요 수 조회 - 존재하지 않는 ID")
+	public void getLikeCount_invalidTargetId() {
+		// given
+		long invalidTargetId = -1L;
+
+		// then
+		ServiceException exception = assertThrows(ServiceException.class,
+			() -> likeService.getPostLikeCount(invalidTargetId));
+		assertNotNull(exception);
+	}
+
+	@Test
+	@DisplayName("포스트 좋아요 상태 조회 - 좋아요 있음")
+	public void getPostLikeStatus_exists() {
+		// given
+		long userId = 1L;
+		long postId = 10L;
+
+		// when
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
+			.thenReturn(true);
+
+		Boolean result = likeService.getPostLikeStatus(userId, postId);
+
+		// then
+		assertTrue(result);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST);
+	}
+
+	@Test
+	@DisplayName("포스트 좋아요 상태 조회 - 좋아요 없음")
+	public void getPostLikeStatus_notExists() {
+		// given
+		long userId = 1L;
+		long postId = 10L;
+
+		// when
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST))
+			.thenReturn(false);
+
+		Boolean result = likeService.getPostLikeStatus(userId, postId);
+
+		// then
+		assertFalse(result);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, postId, TargetType.POST);
+	}
+
+	@Test
+	@DisplayName("댓글 좋아요 상태 조회 - 좋아요 있음")
+	public void getCommentLikeStatus_exists() {
+		// given
+		long userId = 1L;
+		long commentId = 20L;
+
+		// when
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
+			.thenReturn(true);
+
+		Boolean result = likeService.getCommentLikeStatus(userId, commentId);
+
+		// then
+		assertTrue(result);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT);
+	}
+
+	@Test
+	@DisplayName("댓글 좋아요 상태 조회 - 좋아요 없음")
+	public void getCommentLikeStatus_notExists() {
+		// given
+		long userId = 1L;
+		long commentId = 20L;
+
+		// when
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT))
+			.thenReturn(false);
+
+		Boolean result = likeService.getCommentLikeStatus(userId, commentId);
+
+		// then
+		assertFalse(result);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(userId, commentId, TargetType.COMMENT);
+	}
+
+}

--- a/src/test/java/com/ndgl/spotfinder/domain/post/PostServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/post/PostServiceTest.java
@@ -25,7 +25,8 @@ import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.repository.PostRepository;
 import com.ndgl.spotfinder.domain.post.service.PostService;
 import com.ndgl.spotfinder.domain.user.entity.User;
-import com.ndgl.spotfinder.domain.user.repository.UserRepository;
+import com.ndgl.spotfinder.domain.user.service.UserService;
+import com.ndgl.spotfinder.global.exception.ErrorCode;
 import com.ndgl.spotfinder.global.exception.ServiceException;
 
 @ActiveProfiles("test")
@@ -38,7 +39,7 @@ public class PostServiceTest {
 	private PostRepository postRepository;
 
 	@Mock
-	private UserRepository userRepository;
+	private UserService userService;
 
 	private final User user1 = User.builder()
 		.id(1L)
@@ -100,7 +101,7 @@ public class PostServiceTest {
 		);
 
 		// when
-		when(userRepository.findByEmail("이메일1")).thenReturn(Optional.of(user1));
+		when(userService.findUserByEmail("이메일1")).thenReturn(user1);
 		postService.createPost(requestDto, "이메일1");
 
 		// then
@@ -122,7 +123,9 @@ public class PostServiceTest {
 	@Test
 	public void createPost_userNotFound() {
 		// when
-		when(userRepository.findByEmail("이메일1")).thenReturn(Optional.empty());
+		ErrorCode errorCode = ErrorCode.USER_NOT_FOUND;
+		when(userService.findUserByEmail("이메일1"))
+			.thenThrow(new ServiceException(errorCode.getHttpStatus(), errorCode.getMessage()));
 
 		// then
 		ServiceException exception = assertThrows(ServiceException.class,
@@ -150,7 +153,7 @@ public class PostServiceTest {
 		);
 
 		// when
-		when(userRepository.findByEmail("이메일1")).thenReturn(Optional.of(user1));
+		when(userService.findUserByEmail("이메일1")).thenReturn(user1);
 		when(postRepository.findById(1L)).thenReturn(Optional.of(samplePost));
 		postService.updatePost(1L, requestDto, "이메일1");
 
@@ -176,7 +179,7 @@ public class PostServiceTest {
 	@Test
 	public void updatePost_notFound() {
 		// when
-		when(userRepository.findByEmail("이메일1")).thenReturn(Optional.of(user1));
+		when(userService.findUserByEmail("이메일1")).thenReturn(user1);
 		when(postRepository.findById(1L)).thenReturn(Optional.empty());
 
 		// then
@@ -188,7 +191,7 @@ public class PostServiceTest {
 	@Test
 	public void updatePost_AuthorMissMatch() {
 		// when
-		when(userRepository.findByEmail("이메일2")).thenReturn(Optional.of(user2));
+		when(userService.findUserByEmail("이메일2")).thenReturn(user2);
 		when(postRepository.findById(1L)).thenReturn(Optional.of(samplePost));
 
 		// then
@@ -200,7 +203,7 @@ public class PostServiceTest {
 	@Test
 	public void deletePost_success() {
 		// when
-		when(userRepository.findByEmail("이메일1")).thenReturn(Optional.of(user1));
+		when(userService.findUserByEmail("이메일1")).thenReturn(user1);
 		when(postRepository.findById(1L)).thenReturn(Optional.of(samplePost));
 		postService.deletePost(1L, "이메일1");
 
@@ -211,7 +214,7 @@ public class PostServiceTest {
 	@Test
 	public void deletePost_notFound() {
 		// when
-		when(userRepository.findByEmail("이메일1")).thenReturn(Optional.of(user1));
+		when(userService.findUserByEmail("이메일1")).thenReturn(user1);
 		when(postRepository.findById(1L)).thenReturn(Optional.empty());
 
 		// then
@@ -223,7 +226,7 @@ public class PostServiceTest {
 	@Test
 	public void deletePost_AuthorMissMatch() {
 		// when
-		when(userRepository.findByEmail("이메일2")).thenReturn(Optional.of(user2));
+		when(userService.findUserByEmail("이메일2")).thenReturn(user2);
 		when(postRepository.findById(1L)).thenReturn(Optional.of(samplePost));
 
 		// then


### PR DESCRIPTION
## Issue
resolved #57 
resolved #66

## 요구 사항과 구현 내용
- 좋아요 개수가 제대로 증가/감소하지 않는 문제 수정
- 포스트 조회 시 좋아요 개수 및 댓글 개수 포함
  - 조인을 통해 쿼리 실행 수 감소
- 유저 조회 시 Service 코드 사용, 테스트 코드도 이에 맞게 수정