### PR TITLE
관리자 단위 테스트 / 통합 테스트 작성, 관리자 가입 username 중복 체크, Admin 엔티티 수정

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/admin/controller/AdminController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ndgl.spotfinder.domain.admin.dto.CreateAdminRequest;
+import com.ndgl.spotfinder.domain.admin.dto.CreateAdminResponse;
 import com.ndgl.spotfinder.domain.admin.service.AdminService;
 import com.ndgl.spotfinder.global.rsdata.RsData;
 import com.ndgl.spotfinder.global.security.cookie.TokenCookieUtil;
@@ -26,10 +27,10 @@ public class AdminController {
 	private final TokenCookieUtil tokenCookieUtil;
 
 	@PostMapping("/join")
-	public RsData<Void> joinAdmin(@RequestBody @Valid CreateAdminRequest createAdminRequest) {
-		adminService.join(createAdminRequest);
+	public RsData<CreateAdminResponse> joinAdmin(@RequestBody @Valid CreateAdminRequest createAdminRequest) {
+		long adminId = adminService.join(createAdminRequest);
 
-		return RsData.success(HttpStatus.OK);
+		return RsData.success(HttpStatus.OK, new CreateAdminResponse(adminId));
 	}
 
 	@PostMapping("/resign")
@@ -43,6 +44,5 @@ public class AdminController {
 	public RsData<Void> getStatistics() {
 		return RsData.success(HttpStatus.OK);
 	}
-
 
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/admin/controller/AdminController.java
@@ -28,9 +28,9 @@ public class AdminController {
 
 	@PostMapping("/join")
 	public RsData<CreateAdminResponse> joinAdmin(@RequestBody @Valid CreateAdminRequest createAdminRequest) {
-		long adminId = adminService.join(createAdminRequest);
+		CreateAdminResponse createAdminResponse = adminService.join(createAdminRequest);
 
-		return RsData.success(HttpStatus.OK, new CreateAdminResponse(adminId));
+		return RsData.success(HttpStatus.OK, createAdminResponse);
 	}
 
 	@PostMapping("/resign")

--- a/src/main/java/com/ndgl/spotfinder/domain/admin/dto/CreateAdminResponse.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/admin/dto/CreateAdminResponse.java
@@ -1,0 +1,6 @@
+package com.ndgl.spotfinder.domain.admin.dto;
+
+public record CreateAdminResponse(
+	long id
+) {
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/admin/entity/Admin.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/admin/entity/Admin.java
@@ -25,10 +25,10 @@ public class Admin extends BaseTime {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long id;
 
-	@Column(unique = true)
+	@Column(unique = true, nullable = false)
 	String username;
 
-	@Column(unique = true)
+	@Column(nullable = false)
 	String password;
 
 	@Builder

--- a/src/main/java/com/ndgl/spotfinder/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/admin/repository/AdminRepository.java
@@ -10,4 +10,5 @@ import com.ndgl.spotfinder.domain.admin.entity.Admin;
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
 	public Optional<Admin> findByUsername(String username);
+	public boolean existsAdminByUsername(String username);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/admin/service/AdminService.java
@@ -4,6 +4,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.ndgl.spotfinder.domain.admin.dto.CreateAdminRequest;
+import com.ndgl.spotfinder.domain.admin.dto.CreateAdminResponse;
 import com.ndgl.spotfinder.domain.admin.entity.Admin;
 import com.ndgl.spotfinder.domain.admin.repository.AdminRepository;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
@@ -16,7 +17,7 @@ public class AdminService {
 	private final AdminRepository adminRepository;
 	private final PasswordEncoder passwordEncoder;
 
-	public long join(CreateAdminRequest createAdminRequest) {
+	public CreateAdminResponse join(CreateAdminRequest createAdminRequest) {
 		if(adminRepository.existsAdminByUsername(createAdminRequest.username())) {
 			throw ErrorCode.ADMIN_ALREADY_EXISTS_USERNAME.throwServiceException();
 		}
@@ -26,8 +27,8 @@ public class AdminService {
 			.password(passwordEncoder.encode(createAdminRequest.password()))
 			.build();
 
-		admin = adminRepository.save(admin);
-		return admin.getId();
+		Admin savedAdmin = adminRepository.save(admin);
+		return new CreateAdminResponse(savedAdmin.getId());
 	}
 
 	public void resign(String username) {

--- a/src/main/java/com/ndgl/spotfinder/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/admin/service/AdminService.java
@@ -16,13 +16,18 @@ public class AdminService {
 	private final AdminRepository adminRepository;
 	private final PasswordEncoder passwordEncoder;
 
-	public void join(CreateAdminRequest createAdminRequest) {
+	public long join(CreateAdminRequest createAdminRequest) {
+		if(adminRepository.existsAdminByUsername(createAdminRequest.username())) {
+			throw ErrorCode.ADMIN_ALREADY_EXISTS_USERNAME.throwServiceException();
+		}
+
 		Admin admin = Admin.builder()
 			.username(createAdminRequest.username())
 			.password(passwordEncoder.encode(createAdminRequest.password()))
 			.build();
 
-		adminRepository.save(admin);
+		admin = adminRepository.save(admin);
+		return admin.getId();
 	}
 
 	public void resign(String username) {

--- a/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
+++ b/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 
 	ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 관리자입니다."),
+	ADMIN_ALREADY_EXISTS_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 관리자 username 입니다."),
 
 	CONFLICTED_NICKNAME(HttpStatus.CONFLICT, "이미 사용중인 닉네임 입니다."),
 	CONFLICTED_BLOG_NAME(HttpStatus.CONFLICT, "이미 사용중인 블로그 명 입니다."),

--- a/src/main/java/com/ndgl/spotfinder/global/init/ReportTestInit.java
+++ b/src/main/java/com/ndgl/spotfinder/global/init/ReportTestInit.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ndgl.spotfinder.domain.admin.entity.Admin;
@@ -37,6 +38,7 @@ public class ReportTestInit {
 	private final AdminRepository adminRepository;
 	private final PostRepository postRepository;
 	private final PostCommentRepository postCommentRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	@Autowired
 	@Lazy
@@ -60,7 +62,11 @@ public class ReportTestInit {
 			return;
 		}
 		// 테스트 사용자 생성
-		Admin admin = Admin.builder().username("admin").password("12345").build();
+		String username = "admin";
+		String password = "12345";
+		String encodedPassword = passwordEncoder.encode(password);
+
+		Admin admin = Admin.builder().username("admin").password(encodedPassword).build();
 		adminRepository.save(admin);
 	}
 

--- a/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
+++ b/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
@@ -89,9 +89,7 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments/*")
 				.permitAll()
 				// 관리자 권한 필요한 요청
-				.requestMatchers(HttpMethod.GET, "/api/*/admin/logout")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.GET, "/api/*/admin/resign")
+				.requestMatchers(HttpMethod.POST, "/api/*/admin/resign")
 				.hasAuthority("ROLE_ADMIN")
 				.requestMatchers(HttpMethod.GET, "/api/*/admin/posts/statistics")
 				.hasAuthority("ROLE_ADMIN")

--- a/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
+++ b/src/main/java/com/ndgl/spotfinder/global/security/SecurityConfig.java
@@ -82,28 +82,21 @@ public class SecurityConfig {
 				.permitAll()
 				.requestMatchers(HttpMethod.OPTIONS, "/**")// Preflight 요청(CORS)을 허용하여 브라우저의 사전 요청 차단 문제 해결
 				.permitAll()
-				.requestMatchers(HttpMethod.GET, "/api/v1/posts/**")
+				.requestMatchers(HttpMethod.GET,
+					"/api/v1/posts/**",
+					"/api/v1/posts/*/comments",
+					"/api/v1/posts/*/comments/*"
+				)
 				.permitAll()
-				.requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments")
-				.permitAll()
-				.requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments/*")
-				.permitAll()
-				// 관리자 권한 필요한 요청
-				.requestMatchers(HttpMethod.POST, "/api/*/admin/resign")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.GET, "/api/*/admin/posts/statistics")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.GET, "/api/*/reports/posts")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.GET, "/api/*/reports/comments")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.POST, "/api/*/reports/{reportId}/post/ban")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.POST, "/api/*/reports/{reportId}/comment/ban")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.POST, "/api/*/reports/{reportId}/post/reject")
-				.hasAuthority("ROLE_ADMIN")
-				.requestMatchers(HttpMethod.POST, "/api/*/reports/{reportId}/comment/reject")
+				.requestMatchers(HttpMethod.POST,
+					"/api/*/reports/posts/{id}",
+					"/api/*/reports/comments/{id}"
+				)
+				.authenticated()
+				.requestMatchers(
+					"/api/*/admin/**",
+					"/api/*/reports/**"
+				)
 				.hasAuthority("ROLE_ADMIN")
 				.anyRequest()
 				.authenticated()

--- a/src/test/java/com/ndgl/spotfinder/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/admin/controller/AdminControllerTest.java
@@ -1,0 +1,397 @@
+package com.ndgl.spotfinder.domain.admin.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import com.ndgl.spotfinder.domain.admin.dto.CreateAdminRequest;
+import com.ndgl.spotfinder.domain.admin.entity.Admin;
+import com.ndgl.spotfinder.domain.admin.repository.AdminRepository;
+import com.ndgl.spotfinder.domain.admin.service.AdminService;
+import com.ndgl.spotfinder.domain.user.entity.User;
+import com.ndgl.spotfinder.domain.user.service.UserService;
+import com.ndgl.spotfinder.global.exception.ErrorCode;
+import com.ndgl.spotfinder.global.exception.ServiceException;
+import com.ndgl.spotfinder.global.security.jwt.AdminUserDetails;
+import com.ndgl.spotfinder.global.security.jwt.CustomUserDetails;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+@SpringBootTest
+class AdminControllerTest {
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private AdminService adminService;
+
+	@Autowired
+	private AdminRepository adminRepository;
+
+	@Autowired
+	private UserService userService;
+
+
+	void setUpUserAuth(long userId) {
+		User user = userService.findUserById(userId);
+		CustomUserDetails userDetails = new CustomUserDetails(user);
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			userDetails, null, userDetails.getAuthorities()
+		);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+
+	void setUpAdminAuth(String adminUsername) {
+		Admin admin = adminService.findAdminByUsername(adminUsername);
+		AdminUserDetails adminDetails = new AdminUserDetails(admin);
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			adminDetails, null, adminDetails.getAuthorities()
+		);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+
+	@Test
+	@DisplayName("관리자 생성 - 정상")
+	void 정상_관리자_생성() throws Exception {
+
+		String username = "admin1";
+		String password = "admin123";
+
+		CreateAdminRequest createAdminRequest = new CreateAdminRequest(username, password);
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/join")
+				.content(objectMapper.writeValueAsString(createAdminRequest))
+				.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+		);
+
+		resultActions
+			.andExpect(handler().handlerType(AdminController.class))
+			.andExpect(handler().methodName("joinAdmin"))
+			.andExpect(status().isOk());
+
+		// Admin 의 id 값 API 응답에서 추출
+		MvcResult mvcResult = resultActions.andReturn();
+		String responseJson = mvcResult.getResponse().getContentAsString();
+
+		Integer id = JsonPath.read(responseJson, "$.data.id");
+		Admin admin = adminRepository.findById(Long.valueOf(id))
+			.orElseThrow(ErrorCode.ADMIN_NOT_FOUND::throwServiceException);
+
+		assertThat(admin.getUsername()).isEqualTo(username);
+	}
+
+	@Test
+	@DisplayName("관리자 생성 - username 중복")
+	void 비정상_관리자_생성_username_중복() throws Exception {
+
+		String username = "admin";
+		String password = "admin123";
+
+		CreateAdminRequest createAdminRequest = new CreateAdminRequest(username, password);
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/join")
+				.content(objectMapper.writeValueAsString(createAdminRequest))
+				.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+		);
+
+		resultActions
+			.andExpect(handler().handlerType(AdminController.class))
+			.andExpect(handler().methodName("joinAdmin"))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value(ErrorCode.ADMIN_ALREADY_EXISTS_USERNAME.getHttpStatus().value()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.ADMIN_ALREADY_EXISTS_USERNAME.getMessage()));
+	}
+
+	@Test
+	@DisplayName("관리자 생성 - 비정상 username (4자 미만")
+	void 비정상_관리자_생성_비정상_username_4자_미만() throws Exception {
+
+		String invalidUsername = "ad1";
+		String password = "admin123";
+
+		CreateAdminRequest createAdminRequest = new CreateAdminRequest(invalidUsername, password);
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/join")
+				.content(objectMapper.writeValueAsString(createAdminRequest))
+				.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+		);
+
+		resultActions
+			.andExpect(handler().handlerType(AdminController.class))
+			.andExpect(handler().methodName("joinAdmin"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("사용자 이름은 4자 이상 20자 이하여야 합니다."));
+	}
+
+	@Test
+	@DisplayName("관리자 생성 - username 데이터 누락")
+	void 비정상_관리자_생성_username_데이터_누락() throws Exception {
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/join")
+				.content("""
+					{
+						"username" : "",
+						"password" : "admin123"
+					}
+					""")
+				.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+		);
+
+		resultActions
+			.andExpect(handler().handlerType(AdminController.class))
+			.andExpect(handler().methodName("joinAdmin"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message",containsString("사용자 이름은 필수 입력 항목입니다.")));
+	}
+
+	@Test
+	@DisplayName("관리자 생성 - 비정상 password (4자 미만")
+	void 비정상_관리자_생성_비정상_password_4자_미만() throws Exception {
+
+		String username = "admin1";
+		String invalidPassword = "ad1";
+
+		CreateAdminRequest createAdminRequest = new CreateAdminRequest(username, invalidPassword);
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/join")
+				.content(objectMapper.writeValueAsString(createAdminRequest))
+				.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+		);
+
+		resultActions
+			.andExpect(handler().handlerType(AdminController.class))
+			.andExpect(handler().methodName("joinAdmin"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("비밀번호는 4자 이상 20자 이하여야 합니다."));
+	}
+
+	@Test
+	@DisplayName("관리자 생성 - password 데이터 누락")
+	void 비정상_관리자_생성_password_데이터_누락() throws Exception {
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/join")
+				.content("""
+					{
+						"username" : "admin1",
+						"password" : ""
+					}
+					""")
+				.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+		);
+
+		resultActions
+			.andExpect(handler().handlerType(AdminController.class))
+			.andExpect(handler().methodName("joinAdmin"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message", containsString("비밀번호는 필수 입력 항목입니다.")));
+	}
+
+	@Test
+	@DisplayName("관리자 로그인 - 정상")
+	void 정상_관리자_로그인() throws Exception {
+
+		String username = "admin";
+		String password = "12345";
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/login")
+				.param("username", username)
+				.param("password", password)
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+		);
+
+		resultActions
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("관리자 로그인 - 비정상 username")
+	void 비정상_관리자_로그인_비정상_username() throws Exception {
+
+		String username = "invalid";
+		String password = "12345";
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/login")
+				.param("username", username)
+				.param("password", password)
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+		);
+
+		resultActions
+			.andExpect(status().isFound())
+			.andExpect(redirectedUrlPattern("/login?error"));
+	}
+
+	@Test
+	@DisplayName("관리자 로그인 - 비정상 password")
+	void 비정상_관리자_로그인_비정상_password() throws Exception {
+
+		String username = "admin";
+		String password = "invalid";
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/login")
+				.param("username", username)
+				.param("password", password)
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+		);
+
+		resultActions
+			.andExpect(status().isFound())
+			.andExpect(redirectedUrlPattern("/login?error"));
+	}
+
+	@Test
+	@DisplayName("관리자 체크 - 정상")
+	void 정상_관리자_체크() throws Exception {
+
+		setUpAdminAuth("admin");
+
+		ResultActions resultActions = mvc.perform(
+			get("/api/v1/admin/posts/statistics"));
+
+		resultActions
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("관리자 체크 - 권한 X")
+	void 비정상_관리자_체크_권한_X() throws Exception {
+
+		setUpUserAuth(1L);
+
+		ResultActions resultActions = mvc.perform(
+			get("/api/v1/admin/posts/statistics"));
+
+		resultActions
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value(ErrorCode.ACCESS_DENIED.getHttpStatus().value()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.ACCESS_DENIED.getMessage()));
+	}
+
+	@Test
+	@DisplayName("관리자 체크 - 인증 X")
+	void 비정상_관리자_체크_인증_X() throws Exception {
+
+		ResultActions resultActions = mvc.perform(
+			get("/api/v1/admin/posts/statistics"));
+
+		resultActions
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.getHttpStatus().value()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.getMessage()));
+	}
+
+	@Test
+	@DisplayName("관리자 로그아웃 - 정상")
+	void 정상_관리자_로그아웃() throws Exception {
+
+		String adminUsername = "admin";
+		setUpAdminAuth(adminUsername);
+
+		ResultActions resultActions = mvc.perform(
+			get("/api/v1/admin/posts/statistics"));
+
+		resultActions
+			.andExpect(status().isOk());
+
+		resultActions = mvc.perform(
+			post("/api/v1/admin/logout"));
+
+		resultActions
+			.andExpect(status().isOk());
+
+		resultActions = mvc.perform(
+			get("/api/v1/admin/posts/statistics"));
+
+		resultActions
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.getHttpStatus().value()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.getMessage()));
+	}
+
+	@Test
+	@DisplayName("관리자 탈퇴 - 정상")
+	void 정상_관리자_탈퇴() throws Exception {
+
+		String adminUsername = "admin";
+		setUpAdminAuth(adminUsername);
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/resign"));
+
+		resultActions
+			.andExpect(status().isOk());
+
+		assertThatThrownBy(() -> adminService.findAdminByUsername(adminUsername))
+			.isInstanceOf(ServiceException.class)
+			.satisfies(exception -> {
+				ServiceException serviceException = (ServiceException) exception;
+				assertThat(serviceException.getCode()).isEqualTo(ErrorCode.ADMIN_NOT_FOUND.getHttpStatus());
+				assertThat(serviceException.getMessage()).isEqualTo(ErrorCode.ADMIN_NOT_FOUND.getMessage());
+			});
+	}
+
+	@Test
+	@DisplayName("관리자 탈퇴 - 권한 X")
+	void 비정상_관리자_탈퇴_권한_X() throws Exception {
+
+		setUpUserAuth(1L);
+
+		ResultActions resultActions = mvc.perform(
+			post("/api/v1/admin/resign"));
+
+		resultActions
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value(ErrorCode.ACCESS_DENIED.getHttpStatus().value()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.ACCESS_DENIED.getMessage()));
+	}
+
+	@Test
+	@DisplayName("관리자 탈퇴 - 인증 X")
+	void 비정상_관리자_탈퇴_인증_X() throws Exception {
+
+		ResultActions resultActions = mvc.perform(
+			get("/api/v1/admin/resign"));
+
+		resultActions
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.getHttpStatus().value()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.getMessage()));
+	}
+}

--- a/src/test/java/com/ndgl/spotfinder/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/admin/service/AdminServiceTest.java
@@ -1,0 +1,148 @@
+package com.ndgl.spotfinder.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.ndgl.spotfinder.domain.admin.dto.CreateAdminRequest;
+import com.ndgl.spotfinder.domain.admin.entity.Admin;
+import com.ndgl.spotfinder.domain.admin.repository.AdminRepository;
+import com.ndgl.spotfinder.global.exception.ErrorCode;
+import com.ndgl.spotfinder.global.exception.ServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+	@Mock
+	private AdminRepository adminRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	private AdminService adminService;
+
+	private final String USERNAME = "testAdmin";
+	private final String PASSWORD = "password123";
+	private final String ENCODED_PASSWORD = "encodedPassword123";
+
+	@Test
+	@DisplayName("관리자 회원가입 - 정상")
+	void 정상_관리자_회원가입() {
+		// given
+
+		CreateAdminRequest createAdminRequest = new CreateAdminRequest(USERNAME, PASSWORD);
+
+		Admin admin = Admin.builder()
+			.username(USERNAME)
+			.password(ENCODED_PASSWORD)
+			.build();
+
+		Admin savedAdmin = spy(admin);
+		when(savedAdmin.getId()).thenReturn(1L);
+		when(passwordEncoder.encode(PASSWORD)).thenReturn(ENCODED_PASSWORD);
+		when(adminRepository.save(any(Admin.class))).thenReturn(savedAdmin);
+
+		// when
+		adminService.join(createAdminRequest);
+
+		// then
+		verify(passwordEncoder).encode(PASSWORD);
+		verify(adminRepository).save(any(Admin.class));
+	}
+
+	@Test
+	@DisplayName("관리자 회원가입 - username 중복")
+	void 비정상_관리자_회원가입_username_중복() {
+		// given
+		CreateAdminRequest duplicateRequest = new CreateAdminRequest(USERNAME, PASSWORD);
+		when(adminRepository.existsAdminByUsername(anyString())).thenReturn(true);
+
+		// when & then
+		ServiceException exception = assertThrows(ServiceException.class,
+			() -> adminService.join(duplicateRequest));
+
+		assertThat(exception.getCode()).isEqualTo(ErrorCode.ADMIN_ALREADY_EXISTS_USERNAME.getHttpStatus());
+		assertThat(exception.getMessage()).isEqualTo(ErrorCode.ADMIN_ALREADY_EXISTS_USERNAME.getMessage());
+		verify(adminRepository).existsAdminByUsername(duplicateRequest.username());
+	}
+
+	@Test
+	@DisplayName("관리자 계정 탈퇴 - 정상")
+	void 정상_관리자_탈퇴() {
+		// given
+		Admin admin = Admin.builder()
+			.username(USERNAME)
+			.password(ENCODED_PASSWORD)
+			.build();
+		when(adminRepository.findByUsername(USERNAME)).thenReturn(Optional.of(admin));
+
+		// when
+		adminService.resign(USERNAME);
+
+		// then
+		verify(adminRepository).findByUsername(USERNAME);
+		verify(adminRepository).delete(admin);
+	}
+
+	@Test
+	@DisplayName("관리자 계정 탈퇴 - 관리자 존재 X")
+	void 비정상_관리자_탈퇴_관리자_존재_X() {
+		// given
+		when(adminRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+
+		// when & then
+		ServiceException exception = assertThrows(ServiceException.class,
+			() -> adminService.resign("nonExistentAdmin"));
+
+		assertThat(exception.getCode()).isEqualTo(ErrorCode.ADMIN_NOT_FOUND.getHttpStatus());
+		assertThat(exception.getMessage()).isEqualTo(ErrorCode.ADMIN_NOT_FOUND.getMessage());
+		verify(adminRepository).findByUsername("nonExistentAdmin");
+	}
+
+	@Test
+	@DisplayName("username 로 관리자 찾기 - 정상")
+	void 정상_username으로_관리자_찾기() {
+		// given
+		Admin admin = Admin.builder()
+			.username(USERNAME)
+			.password(ENCODED_PASSWORD)
+			.build();
+
+		when(adminRepository.findByUsername(USERNAME)).thenReturn(Optional.of(admin));
+
+		// when
+		Admin foundAdmin = adminService.findAdminByUsername(USERNAME);
+
+		// then
+		assertThat(foundAdmin).isNotNull();
+		assertThat(foundAdmin.getUsername()).isEqualTo(USERNAME);
+		assertThat(foundAdmin.getPassword()).isEqualTo(ENCODED_PASSWORD);
+		verify(adminRepository).findByUsername(USERNAME);
+	}
+
+	@Test
+	@DisplayName("username 로 관리자 찾기 - 관리자 존재 X")
+	void 비정상_username으로_관리자_찾기_관리자_존재_X() {
+		// given
+		when(adminRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+
+		// when & then
+		ServiceException exception = assertThrows(ServiceException.class,
+			() -> adminService.findAdminByUsername("nonExistentAdmin"));
+
+		assertThat(exception.getCode()).isEqualTo(ErrorCode.ADMIN_NOT_FOUND.getHttpStatus());
+		assertThat(exception.getMessage()).isEqualTo(ErrorCode.ADMIN_NOT_FOUND.getMessage());
+		verify(adminRepository).findByUsername("nonExistentAdmin");
+	}
+}


### PR DESCRIPTION
resolves #69 
resolves #70
resolves #71  

1. Admin 엔티티 unique, nullable 설정 변경

2. logout 에서는 인증 / 권한 체크하지 않도록 변경 

3. 관리자 가입에 username 중복 체크 기능 추가

4. 가입 시 생성된 관리자 id를 담은 CreateAdminResponse 반환하도록 변경

5. admin 의 password 를 encodedPassword 로 변경 

6. adminService 단위테스트 작성

7.adminController 통합테스트 작성