### PR TITLE
Jpa like 검색 구현 / elastic search 검색 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 
     // spring-dotenv
     implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+
+    //elasticSearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentDto.java
@@ -2,6 +2,7 @@ package com.ndgl.spotfinder.domain.comment.dto;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
@@ -31,6 +32,7 @@ public class PostCommentDto {
 		this.modifiedAt = comment.getModifiedAt();
 		this.replies = comment.getChildrenComments() == null ? new ArrayList<>()
 			: comment.getChildrenComments().stream()
+			.sorted(Comparator.comparing(PostComment::getId).reversed())
 			.map(PostCommentDto::new)
 			.toList();
 	}

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentReqDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentReqDto.java
@@ -1,10 +1,11 @@
 package com.ndgl.spotfinder.domain.comment.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record PostCommentReqDto(
-	@NotNull @Size(min = 2, max = 100)
+	@NotBlank(message = "댓글 내용은 필수입니다.")
+	@Size(min = 2, max = 100, message = "댓글 내용은 2자 이상 100자 이하입니다.")
 	String content,
 
 	Long parentId

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
@@ -82,14 +82,6 @@ public class PostComment extends BaseTime {
 		}
 	}
 
-	public boolean hasParent() {
-		return parentComment != null;
-	}
-
-	public boolean hasChildren() {
-		return !childrenComments.isEmpty();
-	}
-
 	public void updateLikeCount(long num) {
 		this.likeCount += num;
 	}

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/repository/PostCommentRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/repository/PostCommentRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
 
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
-	Slice<PostComment> findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(Long postId, Long lastId, Pageable pageable);
+	Slice<PostComment> findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/service/PostCommentService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/service/PostCommentService.java
@@ -27,10 +27,12 @@ public class PostCommentService {
 	private final UserRepository userRepository;
 
 	@Transactional(readOnly = true)
-	public SliceResponse<PostCommentDto> getComments(Long postId, long lastId, int size) {
+	public SliceResponse<PostCommentDto> getComments(Long postId, Long lastId, int size) {
 		Pageable pageable = PageRequest.of(0, size);
+		long startId = (lastId != null) ? lastId : Long.MAX_VALUE;
+
 		Slice<PostComment> comments = postCommentRepository
-			.findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(postId, lastId, pageable);
+			.findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, startId, pageable);
 
 		return new SliceResponse<>(
 			comments.stream()

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.domain.search.document.PostDocument;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -44,6 +45,24 @@ public record PostResponseDto(
 			post.getThumbnail(),
 			post.getLikeCount(),
 			post.getComments().size(),
+			post.getCreatedAt(),
+			post.getHashtags()
+				.stream()
+				.limit(3)
+				.map(HashtagDto::new)
+				.toList()
+		);
+	}
+
+	public PostResponseDto(PostDocument post) {
+		this(
+			post.getId(),
+			post.getTitle(),
+			post.getContent(),
+			post.getNickname(),
+			post.getThumbnail(),
+			post.getLikeCount(),
+			0,
 			post.getCreatedAt(),
 			post.getHashtags()
 				.stream()

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
@@ -1,7 +1,9 @@
 package com.ndgl.spotfinder.domain.post.dto;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.search.document.PostDocument;
@@ -64,7 +66,8 @@ public record PostResponseDto(
 			post.getLikeCount(),
 			0,
 			post.getCreatedAt(),
-			post.getHashtags()
+			Optional.ofNullable(post.getHashtags())
+				.orElse(Collections.emptyList())
 				.stream()
 				.limit(3)
 				.map(HashtagDto::new)

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
@@ -71,6 +71,10 @@ public class Post extends BaseTime {
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Location> locations = new ArrayList<>();
 
+	@Builder.Default
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostComment> comments = new ArrayList<>();
+
 	public void addHashtag(Hashtag hashtag) {
 		hashtags.add(hashtag);
 		hashtag.setPost(this);

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
@@ -71,10 +71,6 @@ public class Post extends BaseTime {
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Location> locations = new ArrayList<>();
 
-	@Builder.Default
-	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<PostComment> comments = new ArrayList<>();
-
 	public void addHashtag(Hashtag hashtag) {
 		hashtags.add(hashtag);
 		hashtag.setPost(this);

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/SearchType.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/SearchType.java
@@ -1,7 +1,0 @@
-package com.ndgl.spotfinder.domain.post.entity;
-
-public enum SearchType {
-	TITLE_CONTENT,
-	NICKNAME,
-	HASHTAG,
-}

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/SearchType.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/SearchType.java
@@ -1,0 +1,7 @@
+package com.ndgl.spotfinder.domain.post.entity;
+
+public enum SearchType {
+	TITLE_CONTENT,
+	NICKNAME,
+	HASHTAG,
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -29,12 +29,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 	Optional<Post> findTopByOrderByIdDesc();
 
-	Slice<Post> findByTitleContainingOrContentContainingAndIdGreaterThan(
-		String title, String content, Long lastId, PageRequest pageRequest);
-
-	Slice<Post> findByUser_NickNameContainingAndIdGreaterThan(
-		String nickname, Long lastId, PageRequest pageRequest);
-
-	Slice<Post> findByHashtags_NameContainingAndIdGreaterThan(
-		String hashtag, Long lastId, PageRequest pageRequest);
+	@Query("SELECT p FROM Post p "
+		+ "WHERE (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		+ "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		+ "OR LOWER(p.user.nickName) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		+ "OR EXISTS (SELECT h FROM p.hashtags h WHERE LOWER(h.name) LIKE LOWER(CONCAT('%', :keyword, '%')))) "
+		+ "AND p.id > :lastId")
+	Slice<Post> searchAll(String keyword, Long lastId, PageRequest pageRequest);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -28,4 +28,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		PageRequest pageRequest);
 
 	Optional<Post> findTopByOrderByIdDesc();
+
+	Slice<Post> findByTitleContainingOrContentContainingAndIdGreaterThan(
+		String title, String content, Long lastId, PageRequest pageRequest);
+
+	Slice<Post> findByUser_NickNameContainingAndIdGreaterThan(
+		String nickname, Long lastId, PageRequest pageRequest);
+
+	Slice<Post> findByHashtags_NameContainingAndIdGreaterThan(
+		String hashtag, Long lastId, PageRequest pageRequest);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -94,7 +94,7 @@ public class PostService {
 		}
 	}
 
-	private Long getLastPostId(SliceRequest sliceRequest) {
+	public Long getLastPostId(SliceRequest sliceRequest) {
 		if (sliceRequest.lastId() == null) {
 			return postRepository.findTopByOrderByIdDesc()
 				.map(post -> post.getId() + 1)

--- a/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
@@ -1,0 +1,34 @@
+package com.ndgl.spotfinder.domain.search.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
+import com.ndgl.spotfinder.domain.search.service.PostSearchService;
+import com.ndgl.spotfinder.global.common.dto.SliceRequest;
+import com.ndgl.spotfinder.global.common.dto.SliceResponse;
+import com.ndgl.spotfinder.global.rsdata.RsData;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/posts/search")
+@RequiredArgsConstructor
+public class PostSearchController {
+	private final PostSearchService postSearchService;
+
+	@GetMapping
+	public RsData<SliceResponse<PostResponseDto>> searchPosts(
+		@ModelAttribute @Valid SliceRequest sliceRequest,
+		@RequestParam String keyword
+	) {
+		SliceResponse<PostResponseDto> results = postSearchService.searchPosts(sliceRequest, keyword);
+
+		return RsData.success(HttpStatus.OK, results);
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/search/document/PostDocument.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/document/PostDocument.java
@@ -1,0 +1,49 @@
+package com.ndgl.spotfinder.domain.search.document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Document(indexName = "my_index")
+@Getter
+@AllArgsConstructor
+public class PostDocument {
+	@Id
+	@Field(type = FieldType.Long, index = false)
+	private Long id;
+
+	@Field(type = FieldType.Text, analyzer = "test_analyzer")
+	private String title;
+
+	@Field(type = FieldType.Text, analyzer = "test_analyzer")
+	private String content;
+
+	@Field(type = FieldType.Keyword, index = false)
+	private String nickname;
+
+	@Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+	private LocalDateTime createdAt;
+
+	@Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+	private LocalDateTime updatedAt;
+
+	@Field(type = FieldType.Keyword, index = false)
+	private String thumbnail;
+
+	@Field(type = FieldType.Long, index = false)
+	private Long viewCount;
+
+	@Field(type = FieldType.Long, index = false)
+	private Long likeCount;
+
+	@Field(type = FieldType.Keyword)
+	private List<String> hashtags;
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/search/document/PostDocument.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/document/PostDocument.java
@@ -9,12 +9,19 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
+import com.ndgl.spotfinder.domain.post.entity.Hashtag;
+import com.ndgl.spotfinder.domain.post.entity.Post;
+
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Document(indexName = "my_index")
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class PostDocument {
 	@Id
 	@Field(type = FieldType.Long, index = false)
@@ -46,4 +53,23 @@ public class PostDocument {
 
 	@Field(type = FieldType.Keyword)
 	private List<String> hashtags;
+
+	public static PostDocument from(Post post) {
+		return PostDocument.builder()
+			.id(post.getId())
+			.title(post.getTitle())
+			.content(post.getContent())
+			.nickname(post.getUser().getNickName())
+			.createdAt(post.getCreatedAt())
+			.updatedAt(post.getUpdatedAt())
+			.thumbnail(post.getThumbnail())
+			.viewCount(post.getViewCount())
+			.likeCount(post.getLikeCount())
+			.hashtags(
+				post.getHashtags().stream()
+					.map(Hashtag::getName)
+					.toList()
+			)
+			.build();
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/repository/PostSearchRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/repository/PostSearchRepository.java
@@ -1,0 +1,13 @@
+package com.ndgl.spotfinder.domain.search.repository;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import com.ndgl.spotfinder.domain.search.document.PostDocument;
+
+@ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true")
+public interface PostSearchRepository extends ElasticsearchRepository<PostDocument, Long> {
+	Page<PostDocument> findByTitleOrContent(String title, String content, Pageable pageable);
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
@@ -1,0 +1,84 @@
+package com.ndgl.spotfinder.domain.search.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
+import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.domain.post.repository.PostRepository;
+import com.ndgl.spotfinder.domain.post.service.PostService;
+import com.ndgl.spotfinder.domain.search.document.PostDocument;
+import com.ndgl.spotfinder.domain.search.repository.PostSearchRepository;
+import com.ndgl.spotfinder.global.common.dto.SliceRequest;
+import com.ndgl.spotfinder.global.common.dto.SliceResponse;
+import com.ndgl.spotfinder.global.elk.ElasticSearchHealthCheck;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class PostSearchService {
+	private final PostService postService;
+	private final PostRepository postRepository;
+	private final ElasticSearchHealthCheck healthCheck;
+	private final PostSearchRepository postSearchRepository;
+
+	public PostSearchService(
+		PostService postService,
+		PostRepository postJpaRepository,
+		ElasticSearchHealthCheck healthCheck,
+		@Autowired(required = false) PostSearchRepository postSearchRepository
+	) {
+		this.postService = postService;
+		this.postRepository = postJpaRepository;
+		this.healthCheck = healthCheck;
+		this.postSearchRepository = postSearchRepository;
+	}
+
+
+	@Transactional(readOnly = true)
+	public SliceResponse<PostResponseDto> searchPosts(SliceRequest request, String keyword) {
+		if (healthCheck.isElasticSearchUp()) {
+			return searchWithElasticsearch(request, keyword);
+		} else {
+			return searchWithJpa(request, keyword);
+		}
+	}
+
+	private SliceResponse<PostResponseDto> searchWithElasticsearch(SliceRequest request, String keyword) {
+		if (postSearchRepository == null) {  // ES 서버 비활성 재확인 수행
+			return searchWithJpa(request, keyword);
+		}
+
+		Pageable pageable = PageRequest.of(0, request.size());
+		Page<PostDocument> page = postSearchRepository.findByTitleOrContent(keyword, keyword, pageable);
+
+		log.info("엘라스틱서치 사용");
+		return new SliceResponse<>(
+			page.getContent().stream()
+				.map(PostResponseDto::new)
+				.toList(),
+			page.hasNext()
+		);
+	}
+
+	private SliceResponse<PostResponseDto> searchWithJpa(SliceRequest request, String keyword) {
+		PageRequest pageRequest = PageRequest.of(0, request.size());
+		Long lastId = postService.getLastPostId(request);
+
+		Slice<Post> posts = postRepository.searchAll(keyword, lastId, pageRequest);
+
+		log.info("JPA 사용");
+		return new SliceResponse<>(
+			posts.getContent().stream()
+				.map(PostResponseDto::new)
+				.toList(),
+			posts.hasNext()
+		);
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
@@ -52,11 +52,15 @@ public class PostSearchService {
 
 	private SliceResponse<PostResponseDto> searchWithElasticsearch(SliceRequest request, String keyword) {
 		if (postSearchRepository == null) {  // ES 서버 비활성 재확인 수행
+			log.info("엘라스틱서치 실패");
 			return searchWithJpa(request, keyword);
 		}
 
 		Pageable pageable = PageRequest.of(0, request.size());
 		Page<PostDocument> page = postSearchRepository.findByTitleOrContent(keyword, keyword, pageable);
+
+		log.info("엘라스틱서치 결과 수: {}", page.getTotalElements());
+		page.getContent().forEach(post -> log.info("결과: id={}, title={}", post.getId(), post.getTitle()));
 
 		log.info("엘라스틱서치 사용");
 		return new SliceResponse<>(

--- a/src/main/java/com/ndgl/spotfinder/global/elk/ElasticSearchConfig.java
+++ b/src/main/java/com/ndgl/spotfinder/global/elk/ElasticSearchConfig.java
@@ -1,0 +1,7 @@
+package com.ndgl.spotfinder.global.elk;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticSearchConfig {
+}

--- a/src/main/java/com/ndgl/spotfinder/global/elk/ElasticSearchHealthCheck.java
+++ b/src/main/java/com/ndgl/spotfinder/global/elk/ElasticSearchHealthCheck.java
@@ -1,0 +1,21 @@
+package com.ndgl.spotfinder.global.elk;
+
+import org.springframework.stereotype.Component;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ElasticSearchHealthCheck {
+	private final ElasticsearchClient client;
+
+	public boolean isElasticSearchUp() { // ES 서버 상태 체크
+		try {
+			client.ping();
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/global/elk/ElasticSearchInitIndexer.java
+++ b/src/main/java/com/ndgl/spotfinder/global/elk/ElasticSearchInitIndexer.java
@@ -1,0 +1,49 @@
+package com.ndgl.spotfinder.global.elk;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.domain.post.repository.PostRepository;
+import com.ndgl.spotfinder.domain.search.document.PostDocument;
+import com.ndgl.spotfinder.domain.search.repository.PostSearchRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnBean(PostSearchRepository.class)
+public class ElasticSearchInitIndexer {
+
+	private final PostSearchRepository postSearchRepository;
+	private final PostRepository postRepository;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void initIndexing() {
+		log.info("애플리케이션 기동 후 Elasticsearch 인덱싱 점검 시작");
+
+		long count = postSearchRepository.count();
+		if (count > 0) {
+			log.info("Elasticsearch에 이미 인덱싱된 문서 수: {} → 초기화 후 재인덱싱 진행", count);
+			postSearchRepository.deleteAll();
+		} else {
+			log.info("Elasticsearch 인덱스가 비어있음 → 인덱싱 수행");
+		}
+
+		List<Post> posts = postRepository.findAll();
+		List<PostDocument> documents = posts.stream()
+			.map(PostDocument::from)
+			.toList();
+
+		postSearchRepository.saveAll(documents);
+
+		log.info("Elasticsearch 인덱싱 완료: {}건", documents.size());
+	}
+}
+

--- a/src/main/java/com/ndgl/spotfinder/global/init/BaseInitData.java
+++ b/src/main/java/com/ndgl/spotfinder/global/init/BaseInitData.java
@@ -19,6 +19,8 @@ import com.ndgl.spotfinder.domain.post.entity.Hashtag;
 import com.ndgl.spotfinder.domain.post.entity.Location;
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.repository.PostRepository;
+import com.ndgl.spotfinder.domain.search.document.PostDocument;
+import com.ndgl.spotfinder.domain.search.repository.PostSearchRepository;
 import com.ndgl.spotfinder.domain.user.entity.Oauth;
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.domain.user.repository.OauthRepository;
@@ -38,6 +40,7 @@ public class BaseInitData {
 	private final PostRepository postRepository;
 	private final LikeRepository likeRepository;
 	private final PostCommentRepository postCommentRepository;
+	private final PostSearchRepository postSearchRepository;
 
 	@Autowired
 	@Lazy
@@ -158,7 +161,16 @@ public class BaseInitData {
 			}
 		}
 
+		List<Post> savedPosts = postRepository.findAll();
 		log.debug("게시물 {} 개 생성 완료", postRepository.count());
+
+		if (postSearchRepository != null) {
+			List<PostDocument> docs = savedPosts.stream()
+				.map(PostDocument::from)
+				.toList();
+
+			postSearchRepository.saveAll(docs);
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/ndgl/spotfinder/global/init/BaseInitData.java
+++ b/src/main/java/com/ndgl/spotfinder/global/init/BaseInitData.java
@@ -19,8 +19,6 @@ import com.ndgl.spotfinder.domain.post.entity.Hashtag;
 import com.ndgl.spotfinder.domain.post.entity.Location;
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.repository.PostRepository;
-import com.ndgl.spotfinder.domain.search.document.PostDocument;
-import com.ndgl.spotfinder.domain.search.repository.PostSearchRepository;
 import com.ndgl.spotfinder.domain.user.entity.Oauth;
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.domain.user.repository.OauthRepository;
@@ -40,7 +38,6 @@ public class BaseInitData {
 	private final PostRepository postRepository;
 	private final LikeRepository likeRepository;
 	private final PostCommentRepository postCommentRepository;
-	private final PostSearchRepository postSearchRepository;
 
 	@Autowired
 	@Lazy
@@ -161,16 +158,7 @@ public class BaseInitData {
 			}
 		}
 
-		List<Post> savedPosts = postRepository.findAll();
 		log.debug("게시물 {} 개 생성 완료", postRepository.count());
-
-		if (postSearchRepository != null) {
-			List<PostDocument> docs = savedPosts.stream()
-				.map(PostDocument::from)
-				.toList();
-
-			postSearchRepository.saveAll(docs);
-		}
 	}
 
 	@Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,9 +43,6 @@ spring:
       host: redis_1
       port: 6379
 
-    profiles:
-      active: oauth
-
     elasticsearch:
       repositories:
         enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,13 @@ spring:
       host: redis_1
       port: 6379
 
+    profiles:
+      active: oauth
+
+    elasticsearch:
+      repositories:
+        enabled: true
+
   logging:
     level:
       org.hibernate.SQL: ERROR
@@ -50,6 +57,11 @@ spring:
       org.hibernate.orm.jdbc.extract: ERROR
       org.springframework.data.redis: INFO
       root: INFO
+
+  elasticsearch:
+    uris: http://localhost:9200
+    ssl:
+      verification-mode: none
 
 jwt:
   secret:
@@ -70,3 +82,6 @@ aes:
 
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
+
+elasticsearch:
+  enabled: false

--- a/src/test/java/com/ndgl/spotfinder/domain/comment/service/PostCommentServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/comment/service/PostCommentServiceTest.java
@@ -233,7 +233,7 @@ public class PostCommentServiceTest {
 		Slice<PostComment> commentSlice = new SliceImpl<>(comments.subList(0, size), pageRequest, true);
 
 		// Repository Stub 설정
-		when(postCommentRepository.findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(postId, lastId, pageRequest))
+		when(postCommentRepository.findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, lastId, pageRequest))
 			.thenReturn(commentSlice);
 
 		// When
@@ -244,7 +244,7 @@ public class PostCommentServiceTest {
 		assertEquals(size, response.contents().size());
 		assertTrue(response.hasNext());
 		verify(postCommentRepository, times(1))
-			.findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(postId, lastId, pageRequest);
+			.findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, lastId, pageRequest);
 	}
 
 	@Test
@@ -262,7 +262,7 @@ public class PostCommentServiceTest {
 		Slice<PostComment> commentSlice = new SliceImpl<>(comments.subList(0, toIndex), pageRequest, false);
 
 		// Repository Stub 설정
-		when(postCommentRepository.findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(postId, lastId, pageRequest))
+		when(postCommentRepository.findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, lastId, pageRequest))
 			.thenReturn(commentSlice);
 
 		// When
@@ -273,7 +273,7 @@ public class PostCommentServiceTest {
 		assertEquals(toIndex, response.contents().size());
 		assertFalse(response.hasNext());
 		verify(postCommentRepository, times(1))
-			.findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(postId, lastId, pageRequest);
+			.findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, lastId, pageRequest);
 	}
 
 
@@ -288,7 +288,7 @@ public class PostCommentServiceTest {
 		PageRequest pageRequest = PageRequest.of(0, size);
 		Slice<PostComment> emptySlice = new SliceImpl<>(Collections.emptyList(), pageRequest, false);
 
-		when(postCommentRepository.findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(postId, lastId, pageRequest))
+		when(postCommentRepository.findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, lastId, pageRequest))
 			.thenReturn(emptySlice);
 
 		// When
@@ -299,6 +299,6 @@ public class PostCommentServiceTest {
 		assertTrue(response.contents().isEmpty());
 		assertFalse(response.hasNext());
 		verify(postCommentRepository, times(1))
-			.findByPostIdAndParentCommentIsNullAndIdGreaterThanOrderByIdAsc(postId, lastId, pageRequest);
+			.findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, lastId, pageRequest);
 	}
 }

--- a/src/test/java/com/ndgl/spotfinder/domain/search/PostSearchServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/search/PostSearchServiceTest.java
@@ -1,0 +1,144 @@
+package com.ndgl.spotfinder.domain.search;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
+import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.domain.post.repository.PostRepository;
+import com.ndgl.spotfinder.domain.post.service.PostService;
+import com.ndgl.spotfinder.domain.search.document.PostDocument;
+import com.ndgl.spotfinder.domain.search.repository.PostSearchRepository;
+import com.ndgl.spotfinder.domain.search.service.PostSearchService;
+import com.ndgl.spotfinder.domain.user.entity.User;
+import com.ndgl.spotfinder.global.common.dto.SliceRequest;
+import com.ndgl.spotfinder.global.common.dto.SliceResponse;
+import com.ndgl.spotfinder.global.elk.ElasticSearchHealthCheck;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class PostSearchServiceTest {
+	@InjectMocks
+	private PostSearchService postSearchService;
+
+	@Mock
+	private PostService postService;
+
+	@Mock
+	private PostRepository postRepository;
+
+	@Mock
+	private PostSearchRepository postSearchRepository;
+
+	@Mock
+	private ElasticSearchHealthCheck healthCheck;
+
+	private final User user1 = User.builder()
+		.id(1L)
+		.email("이메일1")
+		.nickName("별명1")
+		.blogName("블로그1")
+		.build();
+
+	private final Post samplePost = Post.builder()
+		.id(1L)
+		.title("제목1")
+		.content("내용1")
+		.user(user1)
+		.build();
+
+	private final PostDocument doc1 = PostDocument.builder()
+		.id(2L)
+		.title("맛집 추천")
+		.content("정말 맛있어요")
+		.build();
+
+	private final PostDocument doc2 = PostDocument.builder()
+		.id(3L)
+		.title("여행 후기")
+		.content("풍경이 좋아요")
+		.build();
+
+	@Test
+	@DisplayName("JPA 기반 like 검색")
+	void search_with_jpa() {
+		// given
+		String keyword = "맛";
+		Long lastId = 10L;
+		int size = 3;
+
+		PageRequest pageRequest = PageRequest.of(0, size + 1);
+		List<Post> posts = List.of(samplePost);
+		Slice<Post> postSlice = new SliceImpl<>(posts, pageRequest, false);
+
+		when(healthCheck.isElasticSearchUp()).thenReturn(false);
+		when(postService.getLastPostId(any(SliceRequest.class))).thenReturn(lastId); // ✅ 추가!
+		when(postRepository.searchAll(eq(keyword), eq(lastId), any(PageRequest.class)))
+			.thenReturn(postSlice);
+
+		postSearchService = new PostSearchService(
+			postService, postRepository, healthCheck, null // ES 비활성화
+		);
+
+		// when
+		SliceResponse<PostResponseDto> result = postSearchService.searchPosts(
+			new SliceRequest(lastId, size),
+			keyword
+		);
+
+		// then
+		assertEquals(1, result.contents().size());
+		assertEquals("제목1", result.contents().get(0).title());
+		assertEquals("별명1", result.contents().get(0).authorName());
+		assertFalse(result.hasNext());
+
+		verify(postRepository, times(1)).searchAll(eq(keyword), eq(lastId), any(PageRequest.class));
+	}
+
+	@Test
+	@DisplayName("엘라스틱서치 기반 검색 - lastId 필터링 및 Slice 변환")
+	void search_with_elasticsearch() {
+		// given
+		String keyword = "맛";
+		Long lastId = 1L;
+		int size = 1;
+
+		PageRequest pageRequest = PageRequest.of(0, size + 1);
+		List<PostDocument> docs = List.of(doc1, doc2);
+		Page<PostDocument> mockPage = new PageImpl<>(docs, pageRequest, docs.size());
+
+		when(healthCheck.isElasticSearchUp()).thenReturn(true);
+		when(postSearchRepository.findByTitleOrContent(keyword, keyword, pageRequest)).thenReturn(mockPage);
+
+		postSearchService = new PostSearchService(
+			postService, postRepository, healthCheck, postSearchRepository
+		);
+
+		// when
+		SliceResponse<PostResponseDto> result = postSearchService.searchPosts(
+			new SliceRequest(lastId, size),
+			keyword
+		);
+
+		// then
+		assertEquals(size, result.contents().size());
+		assertEquals("맛집 추천", result.contents().get(0).title());
+		assertTrue(result.hasNext());
+
+		verify(postSearchRepository, times(1)).findByTitleOrContent(keyword, keyword, pageRequest);
+	}
+}


### PR DESCRIPTION
## Issue
resolved #73
resolved #75

## 요구 사항과 구현 내용
- 댓글 유효성 검사 메시지 추가
- BaseInitData에 댓글 초기 데이터 추가
- jpa like 기반 포스트 검색 구현
- elastic search 연동, title, content기반 검색 수행 구현(해시태그, 사용자 등 기타 조건 추가 예정)
: gradle과 yml파일에 관련 설정 추가
: 현재 로컬 환경에서 테스트 중이라 로컬 url로 임시 설정하였습니다!
```
//elasticSearch
implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch:3.0.0'
```
```yml
spring:
  elasticsearch:
    uris: http://localhost:9200
    ssl:
      verification-mode: none
```