### PR TITLE
팔로우 API, 블로그 목록 API, 팔로우한 블로그 조회 API 구현, 포스트 및 댓글 조회 시 작성자 ID 추가 등

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/blog/controller/BlogApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/controller/BlogApiSpecification.java
@@ -1,0 +1,21 @@
+package com.ndgl.spotfinder.domain.blog.controller;
+
+import java.security.Principal;
+
+import com.ndgl.spotfinder.domain.blog.dto.BlogResponseDto;
+import com.ndgl.spotfinder.global.common.dto.SliceRequest;
+import com.ndgl.spotfinder.global.common.dto.SliceResponse;
+import com.ndgl.spotfinder.global.rsdata.RsData;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "블로그")
+public interface BlogApiSpecification {
+	@Operation(summary = "블로그 목록")
+	RsData<SliceResponse<BlogResponseDto>> getAllBlogs(
+		SliceRequest sliceRequest,
+		@Parameter(hidden = true) Principal principal
+	);
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/controller/BlogController.java
@@ -2,6 +2,7 @@ package com.ndgl.spotfinder.domain.blog.controller;
 
 import java.security.Principal;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import com.ndgl.spotfinder.domain.blog.dto.BlogResponseDto;
 import com.ndgl.spotfinder.domain.blog.service.BlogService;
 import com.ndgl.spotfinder.global.common.dto.SliceRequest;
 import com.ndgl.spotfinder.global.common.dto.SliceResponse;
+import com.ndgl.spotfinder.global.rsdata.RsData;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +20,16 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/blogs")
-public class BlogController {
+public class BlogController implements BlogApiSpecification {
 	private final BlogService blogService;
 
 	@GetMapping()
-	public SliceResponse<BlogResponseDto> getAllBlogs(
+	public RsData<SliceResponse<BlogResponseDto>> getAllBlogs(
 		@ModelAttribute @Valid SliceRequest sliceRequest,
 		Principal principal
 	) {
-		return blogService.getBlogs(sliceRequest, principal.getName());
+		SliceResponse<BlogResponseDto> results = blogService.getBlogs(sliceRequest, principal.getName());
+
+		return RsData.success(HttpStatus.OK, results);
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/controller/BlogController.java
@@ -1,0 +1,31 @@
+package com.ndgl.spotfinder.domain.blog.controller;
+
+import java.security.Principal;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ndgl.spotfinder.domain.blog.dto.BlogResponseDto;
+import com.ndgl.spotfinder.domain.blog.service.BlogService;
+import com.ndgl.spotfinder.global.common.dto.SliceRequest;
+import com.ndgl.spotfinder.global.common.dto.SliceResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/blogs")
+public class BlogController {
+	private final BlogService blogService;
+
+	@GetMapping()
+	public SliceResponse<BlogResponseDto> getAllBlogs(
+		@ModelAttribute @Valid SliceRequest sliceRequest,
+		Principal principal
+	) {
+		return blogService.getBlogs(sliceRequest, principal.getName());
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/blog/dto/BlogResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/dto/BlogResponseDto.java
@@ -2,11 +2,22 @@ package com.ndgl.spotfinder.domain.blog.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record BlogResponseDto(
+	@Schema(description = "ID", example = "1")
 	Long id,
+
+	@Schema(description = "블로그 이름", example = "맛집사냥꾼의 블로그")
 	String blogName,
+
+	@Schema(description = "닉네임", example = "맛집사냥꾼")
 	String nickname,
+
+	@Schema(description = "팔로우 여부", example = "false")
 	Boolean isFollowed,
+
+	@Schema(description = "포스트 목록")
 	List<PostSummeryDto> posts
 ) {
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/blog/dto/BlogResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/dto/BlogResponseDto.java
@@ -1,0 +1,12 @@
+package com.ndgl.spotfinder.domain.blog.dto;
+
+import java.util.List;
+
+public record BlogResponseDto(
+	Long id,
+	String blogName,
+	String nickname,
+	Boolean isFollowed,
+	List<PostSummeryDto> posts
+) {
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/blog/dto/PostSummeryDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/dto/PostSummeryDto.java
@@ -2,8 +2,13 @@ package com.ndgl.spotfinder.domain.blog.dto;
 
 import com.ndgl.spotfinder.domain.post.entity.Post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record PostSummeryDto(
+	@Schema(description = "ID", example = "1")
 	Long id,
+
+	@Schema(description = "제목", example = "맛있는 녀석들에 나온 맛집들")
 	String title
 ) {
 	public PostSummeryDto(Post post) {

--- a/src/main/java/com/ndgl/spotfinder/domain/blog/dto/PostSummeryDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/dto/PostSummeryDto.java
@@ -1,0 +1,12 @@
+package com.ndgl.spotfinder.domain.blog.dto;
+
+import com.ndgl.spotfinder.domain.post.entity.Post;
+
+public record PostSummeryDto(
+	Long id,
+	String title
+) {
+	public PostSummeryDto(Post post) {
+		this(post.getId(), post.getTitle());
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/blog/service/BlogService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/blog/service/BlogService.java
@@ -1,0 +1,62 @@
+package com.ndgl.spotfinder.domain.blog.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import com.ndgl.spotfinder.domain.blog.dto.BlogResponseDto;
+import com.ndgl.spotfinder.domain.blog.dto.PostSummeryDto;
+import com.ndgl.spotfinder.domain.follow.service.FollowService;
+import com.ndgl.spotfinder.domain.post.service.PostService;
+import com.ndgl.spotfinder.domain.user.entity.User;
+import com.ndgl.spotfinder.domain.user.service.UserService;
+import com.ndgl.spotfinder.global.common.dto.SliceRequest;
+import com.ndgl.spotfinder.global.common.dto.SliceResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BlogService {
+	private final UserService userService;
+	private final PostService postService;
+	private final FollowService followService;
+
+	private static final Integer DEFAULT_PREVIEW_POST_COUNT = 3;
+
+	public SliceResponse<BlogResponseDto> getBlogs(SliceRequest sliceRequest, String email) {
+		User currentUser = userService.findUserByEmail(email);
+		Slice<User> users = userService.findUsers(sliceRequest);
+
+		List<BlogResponseDto> posts = users.stream()
+			.filter(user -> user != currentUser)
+			.map(user -> new BlogResponseDto(
+				user.getId(),
+				user.getBlogName(),
+				user.getNickName(),
+				isFollowedUser(currentUser, user),
+				getPostsByUser(user)
+			))
+			.toList();
+
+		return new SliceResponse<>(
+			posts,
+			users.hasNext()
+		);
+	}
+
+	private Boolean isFollowedUser(User follower, User followee) {
+		return followService.isFollowed(follower, followee);
+	}
+
+	private List<PostSummeryDto> getPostsByUser(User user) {
+		return postService.getPostsByUser(user.getId())
+			.stream()
+			.limit(DEFAULT_PREVIEW_POST_COUNT)
+			.map(post -> new PostSummeryDto(
+				post.getId(),
+				post.getTitle()
+			)).toList();
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentDto.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 public class PostCommentDto {
 	private final Long id;
 	private final String content;
+	private final Long authorId;
 	private final String authorName;
 	private final Long postId;
 	private final Long parentId;
@@ -24,6 +25,7 @@ public class PostCommentDto {
 	public PostCommentDto(PostComment comment) {
 		this.id = comment.getId();
 		this.content = comment.getContent();
+		this.authorId = comment.getUser().getId();
 		this.authorName = comment.getUser().getNickName();
 		this.postId = comment.getPost().getId();
 		this.parentId = (comment.getParentComment() != null) ? comment.getParentComment().getId() : null;

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowApiSpecification.java
@@ -1,0 +1,42 @@
+package com.ndgl.spotfinder.domain.follow.controller;
+
+import java.security.Principal;
+
+import com.ndgl.spotfinder.global.rsdata.RsData;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "팔로우")
+public interface FollowApiSpecification {
+	@Operation(
+		summary = "유저 팔로우",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "성공", content = @Content(
+				mediaType = "application/json",
+				examples = @ExampleObject("{\"code\": 200, \"message\": \"OK\"}")
+			))
+		}
+	)
+	RsData<Void> followUser(
+		Long followingId,
+		Principal principal
+	);
+
+	@Operation(
+		summary = "유저 언팔로우",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "성공", content = @Content(
+				mediaType = "application/json",
+				examples = @ExampleObject("{\"code\": 200, \"message\": \"OK\"}")
+			))
+		}
+	)
+	RsData<Void> unfollowUser(
+		Long unfollowingId,
+		Principal principal
+	);
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowController.java
@@ -3,6 +3,7 @@ package com.ndgl.spotfinder.domain.follow.controller;
 import java.security.Principal;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,13 @@ public class FollowController {
 	@PostMapping("/{followingId}")
 	public RsData<Void> followUser(@PathVariable Long followingId, Principal principal) {
 		followService.createFollow(principal.getName(), followingId);
+
+		return RsData.success(HttpStatus.OK);
+	}
+
+	@DeleteMapping("/{unfollowingId}")
+	public RsData<Void> unfollowUser(@PathVariable Long unfollowingId, Principal principal) {
+		followService.deleteFollow(principal.getName(), unfollowingId);
 
 		return RsData.success(HttpStatus.OK);
 	}

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowController.java
@@ -1,0 +1,28 @@
+package com.ndgl.spotfinder.domain.follow.controller;
+
+import java.security.Principal;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ndgl.spotfinder.domain.follow.service.FollowService;
+import com.ndgl.spotfinder.global.rsdata.RsData;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/follow")
+public class FollowController {
+	private final FollowService followService;
+
+	@PostMapping("/{followingId}")
+	public RsData<Void> followUser(@PathVariable Long followingId, Principal principal) {
+		followService.createFollow(principal.getName(), followingId);
+
+		return RsData.success(HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/controller/FollowController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/follow")
-public class FollowController {
+public class FollowController implements FollowApiSpecification {
 	private final FollowService followService;
 
 	@PostMapping("/{followingId}")

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/entity/Follow.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/entity/Follow.java
@@ -1,0 +1,34 @@
+package com.ndgl.spotfinder.domain.follow.entity;
+
+import com.ndgl.spotfinder.domain.user.entity.User;
+import com.ndgl.spotfinder.global.base.BaseTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Follow extends BaseTime {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "follower_id")
+	private User follower;
+
+	@ManyToOne
+	@JoinColumn(name = "followee_id")
+	private User followee;
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/repository/FollowRepository.java
@@ -7,4 +7,8 @@ import com.ndgl.spotfinder.domain.user.entity.User;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 	Boolean existsFollowByFollowerAndFollowee(User follower, User following);
+
+	Boolean existsNotFollowByFollowerAndFollowee(User follower, User followee);
+	
+	void deleteFollowByFollowerAndFollowee(User follower, User followee);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,10 @@
+package com.ndgl.spotfinder.domain.follow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ndgl.spotfinder.domain.follow.entity.Follow;
+import com.ndgl.spotfinder.domain.user.entity.User;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+	Boolean existsFollowByFollowerAndFollowee(User follower, User following);
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/service/FollowService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/service/FollowService.java
@@ -1,6 +1,7 @@
 package com.ndgl.spotfinder.domain.follow.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ndgl.spotfinder.domain.follow.entity.Follow;
 import com.ndgl.spotfinder.domain.follow.repository.FollowRepository;
@@ -16,11 +17,12 @@ public class FollowService {
 	private final FollowRepository followRepository;
 	private final UserService userService;
 
+	@Transactional
 	public void createFollow(String email, Long followingId) {
 		User follower = userService.findUserByEmail(email);
 		User followee = userService.findUserById(followingId);
 
-		checkIfAlreadyFollowed(follower, followee);
+		checkIfAlreadyFollowing(follower, followee);
 
 		Follow follow = Follow.builder()
 			.follower(follower)
@@ -30,11 +32,28 @@ public class FollowService {
 		followRepository.save(follow);
 	}
 
-	private void checkIfAlreadyFollowed(User follower, User followee) {
-		Boolean isFollowed = followRepository.existsFollowByFollowerAndFollowee(follower, followee);
+	@Transactional
+	public void deleteFollow(String email, Long unfollowingId) {
+		User follower = userService.findUserByEmail(email);
+		User followee = userService.findUserById(unfollowingId);
 
-		if (isFollowed) {
+		checkIfNotFollowing(follower, followee);
+		followRepository.deleteFollowByFollowerAndFollowee(follower, followee);
+	}
+
+	private void checkIfAlreadyFollowing(User follower, User followee) {
+		if (isFollowed(follower, followee)) {
 			ErrorCode.ALREADY_FOLLOWED.throwServiceException();
 		}
+	}
+
+	private void checkIfNotFollowing(User follower, User followee) {
+		if (!isFollowed(follower, followee)) {
+			ErrorCode.NOT_FOLLOWED.throwServiceException();
+		}
+	}
+
+	private Boolean isFollowed(User follower, User followee) {
+		return followRepository.existsFollowByFollowerAndFollowee(follower, followee);
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/service/FollowService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/service/FollowService.java
@@ -53,7 +53,7 @@ public class FollowService {
 		}
 	}
 
-	private Boolean isFollowed(User follower, User followee) {
+	public Boolean isFollowed(User follower, User followee) {
 		return followRepository.existsFollowByFollowerAndFollowee(follower, followee);
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/follow/service/FollowService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/follow/service/FollowService.java
@@ -1,0 +1,40 @@
+package com.ndgl.spotfinder.domain.follow.service;
+
+import org.springframework.stereotype.Service;
+
+import com.ndgl.spotfinder.domain.follow.entity.Follow;
+import com.ndgl.spotfinder.domain.follow.repository.FollowRepository;
+import com.ndgl.spotfinder.domain.user.entity.User;
+import com.ndgl.spotfinder.domain.user.service.UserService;
+import com.ndgl.spotfinder.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+	private final FollowRepository followRepository;
+	private final UserService userService;
+
+	public void createFollow(String email, Long followingId) {
+		User follower = userService.findUserByEmail(email);
+		User followee = userService.findUserById(followingId);
+
+		checkIfAlreadyFollowed(follower, followee);
+
+		Follow follow = Follow.builder()
+			.follower(follower)
+			.followee(followee)
+			.build();
+
+		followRepository.save(follow);
+	}
+
+	private void checkIfAlreadyFollowed(User follower, User followee) {
+		Boolean isFollowed = followRepository.existsFollowByFollowerAndFollowee(follower, followee);
+
+		if (isFollowed) {
+			ErrorCode.ALREADY_FOLLOWED.throwServiceException();
+		}
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostApiSpecification.java
@@ -15,18 +15,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "포스트")
 public interface PostApiSpecification {
-	@Operation(
-		summary = "포스트 생성",
-		responses = {
-			@ApiResponse(responseCode = "200", description = "성공", content = @Content(
-				mediaType = "application/json",
-				examples = @ExampleObject("{\"code\": 200, \"message\": \"OK\"}")
-			))
-		}
-	)
-	RsData<String> createPost(
+	@Operation(summary = "포스트 생성")
+	RsData<Void> createPost(
 		PostCreateRequestDto postCreateRequestDto,
 		@Parameter(hidden = true) Principal principal
 	);
@@ -40,7 +34,7 @@ public interface PostApiSpecification {
 			))
 		}
 	)
-	RsData<String> updatePost(
+	RsData<Void> updatePost(
 		@Parameter(description = "게시물의 ID") Long id,
 		PostUpdateRequestDto postUpdateRequestDto,
 		@Parameter(hidden = true) Principal principal
@@ -55,7 +49,7 @@ public interface PostApiSpecification {
 			))
 		}
 	)
-	RsData<String> deletePost(
+	RsData<Void> deletePost(
 		@Parameter(description = "게시물의 ID") Long id,
 		@Parameter(hidden = true) Principal principal
 	);

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostApiSpecification.java
@@ -76,8 +76,14 @@ public interface PostApiSpecification {
 		SliceRequest sliceRequest
 	);
 
-	@Operation(summary = "자신이 좋아요한 포스트 목록 조회")
+	@Operation(summary = "사용자가 좋아요한 포스트 목록 조회")
 	RsData<SliceResponse<PostResponseDto>> getPostsByLike(
+		SliceRequest sliceRequest,
+		@Parameter(hidden = true) Principal principal
+	);
+
+	@Operation(summary = "사용자가 팔로우한 블로그의 포스트 목록 조회")
+	RsData<SliceResponse<PostResponseDto>> getPostsByFollow(
 		SliceRequest sliceRequest,
 		@Parameter(hidden = true) Principal principal
 	);

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
@@ -22,11 +22,9 @@ import com.ndgl.spotfinder.global.common.dto.SliceRequest;
 import com.ndgl.spotfinder.global.common.dto.SliceResponse;
 import com.ndgl.spotfinder.global.rsdata.RsData;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "포스트")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts")
@@ -34,7 +32,7 @@ public class PostController implements PostApiSpecification {
 	private final PostService postService;
 
 	@PostMapping
-	public RsData<String> createPost(
+	public RsData<Void> createPost(
 		@RequestBody @Valid PostCreateRequestDto postCreateRequestDto,
 		Principal principal
 	) {
@@ -44,7 +42,7 @@ public class PostController implements PostApiSpecification {
 	}
 
 	@PutMapping("/{id}")
-	public RsData<String> updatePost(
+	public RsData<Void> updatePost(
 		@PathVariable Long id,
 		@RequestBody @Valid PostUpdateRequestDto postUpdateRequestDto,
 		Principal principal
@@ -55,7 +53,7 @@ public class PostController implements PostApiSpecification {
 	}
 
 	@DeleteMapping("/{id}")
-	public RsData<String> deletePost(
+	public RsData<Void> deletePost(
 		@PathVariable Long id,
 		Principal principal
 	) {

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
@@ -95,4 +95,14 @@ public class PostController implements PostApiSpecification {
 
 		return RsData.success(HttpStatus.OK, results);
 	}
+
+	@GetMapping("/follow")
+	public RsData<SliceResponse<PostResponseDto>> getPostsByFollow(
+		@ModelAttribute @Valid SliceRequest sliceRequest,
+		Principal principal
+	) {
+		SliceResponse<PostResponseDto> results = postService.getPostsByFollow(sliceRequest, principal.getName());
+
+		return RsData.success(HttpStatus.OK, results);
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/HashtagDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/HashtagDto.java
@@ -2,10 +2,12 @@ package com.ndgl.spotfinder.domain.post.dto;
 
 import com.ndgl.spotfinder.domain.post.entity.Hashtag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record HashtagDto(
+	@Schema(description = "이름", example = "맛집")
 	@NotBlank(message = "해시태그 이름은 필수입니다.")
 	@Size(max = 30, message = "해시태그는 30자 이하입니다.")
 	String name

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/LocationDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/LocationDto.java
@@ -2,6 +2,7 @@ package com.ndgl.spotfinder.domain.post.dto;
 
 import com.ndgl.spotfinder.domain.post.entity.Location;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -9,20 +10,25 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 
 public record LocationDto(
+	@Schema(description = "장소 이름", example = "식당")
 	@NotBlank(message = "장소 이름은 필수입니다.")
 	String name,
 
+	@Schema(description = "장소 주소", example = "서울시")
 	@NotBlank(message = "장소 주소는 필수입니다.")
 	String address,
 
+	@Schema(description = "위도", example = "36.0")
 	@DecimalMin(value = "-90.0", message = "위도는 -90 이상입니다.")
 	@DecimalMax(value = "90.0", message = "위도는 90 이하입니다.")
 	Double latitude,
 
+	@Schema(description = "경도", example = "127.0")
 	@DecimalMin(value = "-180.0", message = "경도는 -180 이상입니다.")
 	@DecimalMax(value = "180.0", message = "경도는 180 이하입니다.")
 	Double longitude,
 
+	@Schema(description = "순서", example = "1")
 	@Min(value = 1, message = "순서는 1 이상입니다.")
 	@Max(value = 20, message = "순서는 20 이하입니다.")
 	Integer sequence
@@ -36,7 +42,7 @@ public record LocationDto(
 			location.getSequence()
 		);
 	}
-	
+
 	public Location toLocation() {
 		return Location.builder()
 			.name(name)

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/LocationDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/LocationDto.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record LocationDto(
 	@Schema(description = "장소 이름", example = "식당")
@@ -19,16 +20,19 @@ public record LocationDto(
 	String address,
 
 	@Schema(description = "위도", example = "36.0")
+	@NotNull(message = "위도는 필수입니다.")
 	@DecimalMin(value = "-90.0", message = "위도는 -90 이상입니다.")
 	@DecimalMax(value = "90.0", message = "위도는 90 이하입니다.")
 	Double latitude,
 
 	@Schema(description = "경도", example = "127.0")
+	@NotNull(message = "경도는 필수입니다.")
 	@DecimalMin(value = "-180.0", message = "경도는 -180 이상입니다.")
 	@DecimalMax(value = "180.0", message = "경도는 180 이하입니다.")
 	Double longitude,
 
 	@Schema(description = "순서", example = "1")
+	@NotNull(message = "장소 순서는 필수입니다.")
 	@Min(value = 1, message = "순서는 1 이상입니다.")
 	@Max(value = 20, message = "순서는 20 이하입니다.")
 	Integer sequence

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostCreateRequestDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostCreateRequestDto.java
@@ -50,8 +50,6 @@ public record PostCreateRequestDto(
 			.content(content)
 			.user(user)
 			.thumbnail(thumbnail)
-			.viewCount(0L)
-			.likeCount(0L)
 			.build();
 
 		post.addHashtags(hashtagEntities);

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostDetailResponseDto.java
@@ -17,6 +17,9 @@ public record PostDetailResponseDto(
 	@Schema(description = "내용", example = "TV 예능 맛있는 녀석들에 나온 맛집들입니다.")
 	String content,
 
+	@Schema(description = "작성자 아이디", example = "2")
+	Long authorId,
+
 	@Schema(description = "작성자 이름", example = "맛집사냥꾼")
 	String authorName,
 
@@ -43,6 +46,7 @@ public record PostDetailResponseDto(
 			post.getId(),
 			post.getTitle(),
 			post.getContent(),
+			post.getUser().getId(),
 			post.getUser().getNickName(),
 			post.getThumbnail(),
 			post.getLikeCount(),

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
@@ -20,6 +20,9 @@ public record PostResponseDto(
 	@Schema(description = "내용", example = "TV 예능 맛있는 녀석들에 나온 맛집들입니다.")
 	String content,
 
+	@Schema(description = "작성자 아이디", example = "2")
+	Long authorId,
+
 	@Schema(description = "작성자 이름", example = "맛집사냥꾼")
 	String authorName,
 
@@ -45,6 +48,7 @@ public record PostResponseDto(
 			post.getId(),
 			post.getTitle(),
 			post.getContent(),
+			post.getUser().getId(),
 			post.getUser().getNickName(),
 			post.getThumbnail(),
 			post.getLikeCount(),
@@ -63,6 +67,7 @@ public record PostResponseDto(
 			post.getId(),
 			post.getTitle(),
 			post.getContent(),
+			post.getUserId(),
 			post.getNickname(),
 			post.getThumbnail(),
 			post.getLikeCount(),

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
@@ -38,6 +38,8 @@ public record PostResponseDto(
 	@Schema(description = "해시태그 목록")
 	List<HashtagDto> hashtags
 ) {
+	private static final Long POST_LIST_HASHTAG_COUNT = 3L;
+
 	public PostResponseDto(Post post) {
 		this(
 			post.getId(),
@@ -50,7 +52,7 @@ public record PostResponseDto(
 			post.getCreatedAt(),
 			post.getHashtags()
 				.stream()
-				.limit(3)
+				.limit(POST_LIST_HASHTAG_COUNT)
 				.map(HashtagDto::new)
 				.toList()
 		);

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostUpdateRequestDto.java
@@ -2,6 +2,10 @@ package com.ndgl.spotfinder.domain.post.dto;
 
 import java.util.List;
 
+import com.ndgl.spotfinder.domain.post.entity.Hashtag;
+import com.ndgl.spotfinder.domain.post.entity.Location;
+import com.ndgl.spotfinder.domain.post.entity.Post;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -29,4 +33,23 @@ public record PostUpdateRequestDto(
 	@NotNull(message = "썸네일 이미지는 필수입니다.")
 	String thumbnail
 ) {
+	public Post toUpdatedPost(Post post) {
+		post.setTitle(title);
+		post.setContent(content);
+		post.setThumbnail(thumbnail);
+
+		List<Hashtag> newHashtags = hashtags
+			.stream()
+			.map(HashtagDto::toHashtag)
+			.toList();
+		post.updateHashtags(newHashtags);
+
+		List<Location> newLocations = locations
+			.stream()
+			.map(LocationDto::toLocation)
+			.toList();
+		post.updateLocations(newLocations);
+
+		return post;
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
@@ -4,12 +4,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
-import com.ndgl.spotfinder.domain.post.dto.HashtagDto;
-import com.ndgl.spotfinder.domain.post.dto.LocationDto;
-import com.ndgl.spotfinder.domain.post.dto.PostUpdateRequestDto;
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.global.base.BaseTime;
 
@@ -27,20 +25,24 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@DynamicUpdate
 @Entity
 public class Post extends BaseTime {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Setter
 	@Column(length = 100)
 	private String title;
 
+	@Setter
 	@Column(columnDefinition = "TEXT")
 	private String content;
 
@@ -51,6 +53,7 @@ public class Post extends BaseTime {
 	@JoinColumn(name = "user_id")
 	private User user;
 
+	@Setter
 	private String thumbnail;
 
 	@Builder.Default
@@ -87,26 +90,6 @@ public class Post extends BaseTime {
 
 	public void addLocations(List<Location> locations) {
 		locations.forEach(this::addLocation);
-	}
-
-	public Post updatePost(PostUpdateRequestDto requestDto) {
-		title = requestDto.title();
-		content = requestDto.content();
-		thumbnail = requestDto.thumbnail();
-
-		List<Hashtag> newHashtags = requestDto.hashtags()
-			.stream()
-			.map(HashtagDto::toHashtag)
-			.toList();
-		updateHashtags(newHashtags);
-
-		List<Location> newLocations = requestDto.locations()
-			.stream()
-			.map(LocationDto::toLocation)
-			.toList();
-		updateLocations(newLocations);
-
-		return this;
 	}
 
 	public void updateHashtags(List<Hashtag> newHashtags) {

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
@@ -31,7 +30,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@DynamicUpdate
 @Entity
 public class Post extends BaseTime {
 	@Id

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -27,13 +27,21 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	Slice<Post> findLikedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
 		PageRequest pageRequest);
 
+	@Query("SELECT p FROM Post p " +
+		   "JOIN Follow f ON f.follower.id = :userId AND f.followee.id = p.user.id " +
+		   "WHERE p.id < :lastId " +
+		   "ORDER BY p.createdAt DESC")
+	@EntityGraph(attributePaths = {"hashtags"})
+	Slice<Post> findFollowedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
+		PageRequest pageRequest);
+
 	Optional<Post> findTopByOrderByIdDesc();
 
 	@Query("SELECT p FROM Post p "
-		+ "WHERE (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-		+ "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-		+ "OR LOWER(p.user.nickName) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-		+ "OR EXISTS (SELECT h FROM p.hashtags h WHERE LOWER(h.name) LIKE LOWER(CONCAT('%', :keyword, '%')))) "
-		+ "AND p.id > :lastId")
+		   + "WHERE (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		   + "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		   + "OR LOWER(p.user.nickName) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		   + "OR EXISTS (SELECT h FROM p.hashtags h WHERE LOWER(h.name) LIKE LOWER(CONCAT('%', :keyword, '%')))) "
+		   + "AND p.id > :lastId")
 	Slice<Post> searchAll(String keyword, Long lastId, PageRequest pageRequest);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.ndgl.spotfinder.domain.post.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
@@ -44,4 +45,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		   + "OR EXISTS (SELECT h FROM p.hashtags h WHERE LOWER(h.name) LIKE LOWER(CONCAT('%', :keyword, '%')))) "
 		   + "AND p.id > :lastId")
 	Slice<Post> searchAll(String keyword, Long lastId, PageRequest pageRequest);
+
+	List<Post> findByUser(User user);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.ndgl.spotfinder.domain.post.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -72,6 +74,13 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
+	public List<Post> getPostsByUser(Long userId) {
+		User user = userService.findUserById(userId);
+
+		return postRepository.findByUser(user);
+	}
+
+	@Transactional(readOnly = true)
 	public PostDetailResponseDto getPost(Long id) {
 		Post post = findPostById(id);
 
@@ -96,7 +105,7 @@ public class PostService {
 		User user = userService.findUserByEmail(email);
 
 		Slice<Post> results = postRepository.findFollowedPostsByUser(user.getId(), lastId, pageRequest);
-		
+
 		return convertToSliceResponse(results);
 	}
 

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -25,6 +25,8 @@ public class PostService {
 	private final PostRepository postRepository;
 	private final UserService userService;
 
+	private static final Long DEFAULT_LAST_ID = 0L;
+
 	@Transactional
 	public void createPost(PostCreateRequestDto requestDto, String email) {
 		User user = userService.findUserByEmail(email);
@@ -48,6 +50,7 @@ public class PostService {
 		postRepository.delete(post);
 	}
 
+	@Transactional(readOnly = true)
 	public SliceResponse<PostResponseDto> getPosts(SliceRequest sliceRequest) {
 		PageRequest pageRequest = PageRequest.of(0, sliceRequest.size());
 		Long lastId = getLastPostId(sliceRequest);
@@ -57,6 +60,7 @@ public class PostService {
 		return convertToSliceResponse(results);
 	}
 
+	@Transactional(readOnly = true)
 	public SliceResponse<PostResponseDto> getPostsByUser(SliceRequest sliceRequest, Long userId) {
 		PageRequest pageRequest = PageRequest.of(0, sliceRequest.size());
 		Long lastId = getLastPostId(sliceRequest);
@@ -67,12 +71,14 @@ public class PostService {
 		return convertToSliceResponse(results);
 	}
 
+	@Transactional(readOnly = true)
 	public PostDetailResponseDto getPost(Long id) {
 		Post post = findPostById(id);
 
 		return new PostDetailResponseDto(post);
 	}
 
+	@Transactional(readOnly = true)
 	public SliceResponse<PostResponseDto> getPostsByLike(SliceRequest sliceRequest, String email) {
 		PageRequest pageRequest = PageRequest.of(0, sliceRequest.size());
 		Long lastId = getLastPostId(sliceRequest);
@@ -83,6 +89,7 @@ public class PostService {
 		return convertToSliceResponse(results);
 	}
 
+	@Transactional(readOnly = true)
 	public Post findPostById(Long id) {
 		return postRepository.findById(id)
 			.orElseThrow(ErrorCode.POST_NOT_FOUND::throwServiceException);
@@ -98,7 +105,7 @@ public class PostService {
 		if (sliceRequest.lastId() == null) {
 			return postRepository.findTopByOrderByIdDesc()
 				.map(post -> post.getId() + 1)
-				.orElse(0L);
+				.orElse(DEFAULT_LAST_ID);
 		} else {
 			return sliceRequest.lastId();
 		}

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -39,7 +39,7 @@ public class PostService {
 		Post post = findPostById(id);
 
 		checkUserPermission(post, email);
-		postRepository.save(post.updatePost(requestDto));
+		postRepository.save(requestDto.toUpdatedPost(post));
 	}
 
 	@Transactional

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -95,12 +95,7 @@ public class PostService {
 			.orElseThrow(ErrorCode.POST_NOT_FOUND::throwServiceException);
 	}
 
-	private void checkUserPermission(Post post, String email) {
-		if (!post.getUser().getEmail().equals(email)) {
-			ErrorCode.POST_ACCESS_DENIED.throwServiceException();
-		}
-	}
-
+	@Transactional(readOnly = true)
 	public Long getLastPostId(SliceRequest sliceRequest) {
 		if (sliceRequest.lastId() == null) {
 			return postRepository.findTopByOrderByIdDesc()
@@ -108,6 +103,12 @@ public class PostService {
 				.orElse(DEFAULT_LAST_ID);
 		} else {
 			return sliceRequest.lastId();
+		}
+	}
+
+	private void checkUserPermission(Post post, String email) {
+		if (!post.getUser().getEmail().equals(email)) {
+			ErrorCode.POST_ACCESS_DENIED.throwServiceException();
 		}
 	}
 

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -90,6 +90,17 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
+	public SliceResponse<PostResponseDto> getPostsByFollow(SliceRequest sliceRequest, String email) {
+		PageRequest pageRequest = PageRequest.of(0, sliceRequest.size());
+		Long lastId = getLastPostId(sliceRequest);
+		User user = userService.findUserByEmail(email);
+
+		Slice<Post> results = postRepository.findFollowedPostsByUser(user.getId(), lastId, pageRequest);
+		
+		return convertToSliceResponse(results);
+	}
+
+	@Transactional(readOnly = true)
 	public Post findPostById(Long id) {
 		return postRepository.findById(id)
 			.orElseThrow(ErrorCode.POST_NOT_FOUND::throwServiceException);

--- a/src/main/java/com/ndgl/spotfinder/domain/search/document/PostDocument.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/document/PostDocument.java
@@ -34,6 +34,9 @@ public class PostDocument {
 	private String content;
 
 	@Field(type = FieldType.Keyword, index = false)
+	private Long userId;
+
+	@Field(type = FieldType.Keyword, index = false)
 	private String nickname;
 
 	@Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
@@ -59,6 +62,7 @@ public class PostDocument {
 			.id(post.getId())
 			.title(post.getTitle())
 			.content(post.getContent())
+			.userId(post.getUser().getId())
 			.nickname(post.getUser().getNickName())
 			.createdAt(post.getCreatedAt())
 			.updatedAt(post.getUpdatedAt())

--- a/src/main/java/com/ndgl/spotfinder/domain/user/entity/User.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.ndgl.spotfinder.domain.user.entity;
 
-import java.util.Set;
+import java.util.List;
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -54,6 +54,6 @@ public class User extends BaseTime {
 	@Builder.Default
 	private boolean isBanned = false;
 
-	@OneToMany(mappedBy = "follower")
-	private Set<Follow> followings;
+	@OneToMany(mappedBy = "followee")
+	private List<Follow> followings;
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/entity/User.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/entity/User.java
@@ -1,7 +1,10 @@
 package com.ndgl.spotfinder.domain.user.entity;
 
+import java.util.Set;
+
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.ndgl.spotfinder.domain.follow.entity.Follow;
 import com.ndgl.spotfinder.global.base.BaseTime;
 
 import jakarta.persistence.Column;
@@ -10,6 +13,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
@@ -49,4 +53,7 @@ public class User extends BaseTime {
 	@Column(nullable = false)
 	@Builder.Default
 	private boolean isBanned = false;
+
+	@OneToMany(mappedBy = "follower")
+	private Set<Follow> followings;
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.ndgl.spotfinder.domain.user.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ndgl.spotfinder.domain.user.entity.User;
@@ -13,4 +15,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByBlogName(String blogName);
 
+	Slice<User> findAllByIdGreaterThan(Long idIsGreaterThan, Pageable pageable);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/service/UserService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/service/UserService.java
@@ -1,9 +1,12 @@
 package com.ndgl.spotfinder.domain.user.service;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.domain.user.repository.UserRepository;
+import com.ndgl.spotfinder.global.common.dto.SliceRequest;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
+
+	public Slice<User> findUsers(SliceRequest sliceRequest) {
+		PageRequest pageRequest = PageRequest.of(0, sliceRequest.size());
+		Long lastId = sliceRequest.lastId() == null ? 0 : sliceRequest.lastId();
+
+		return userRepository.findAllByIdGreaterThan(lastId, pageRequest);
+	}
 
 	public User findUserById(long userId) {
 		return userRepository.findById(userId)

--- a/src/main/java/com/ndgl/spotfinder/global/common/dto/SliceRequest.java
+++ b/src/main/java/com/ndgl/spotfinder/global/common/dto/SliceRequest.java
@@ -11,7 +11,7 @@ public record SliceRequest(
 	Long lastId,
 
 	@Schema(description = "한 번에 요청할 데이터 개수", example = "5")
-	@NotNull
+	@NotNull(message = "size를 지정해야 합니다.")
 	@Positive(message = "요청 Slice 사이즈는 양수여야 합니다.")
 	Integer size
 ) {

--- a/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
+++ b/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
@@ -46,7 +46,9 @@ public enum ErrorCode {
 	MISSING_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token 이 유효하지 않습니다."),
 	EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token 이 만료되었습니다."),
 
-	UNREADABLE_REQUEST_PAYLOAD(HttpStatus.BAD_REQUEST, "요청 데이터 파싱을 실패하였습니다.");
+	UNREADABLE_REQUEST_PAYLOAD(HttpStatus.BAD_REQUEST, "요청 데이터 파싱을 실패하였습니다."),
+
+	ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우한 유저입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
+++ b/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
@@ -48,7 +48,8 @@ public enum ErrorCode {
 
 	UNREADABLE_REQUEST_PAYLOAD(HttpStatus.BAD_REQUEST, "요청 데이터 파싱을 실패하였습니다."),
 
-	ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우한 유저입니다.");
+	ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우한 유저입니다."),
+	NOT_FOLLOWED(HttpStatus.NOT_FOUND, "팔로우한 유저가 아닙니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;


### PR DESCRIPTION
## Issue
resolved #80
resolved #81
resolved #82
resolved #83
resolved #85
resolved #88

## 요구 사항과 구현 내용
- 유저 팔로우/언팔로우 API 구현
- 팔로우한 블로그의 글 목록 조회 API 구현
- 전체 블로그 목록 조회 API 구현
- 포스트/댓글 조회 시 작성자 ID 추가
- Swagger 관련 코드 추가 및 수정
- 읽기 전용 Transaction 명시
- 코드 리팩터링
  - 상수 분리
  - 포스트 업데이트 로직 분리