### PR TITLE
마이페이지 조회, 회원 정보 수정 기능, 회원 탈퇴 기능 버그 수정. 

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.ndgl.spotfinder.domain.user.controller;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -89,7 +88,10 @@ public class UserController {
 	}
 
 	@GetMapping("/info")
-	public RsData<UserInfoResponseDto> userInfo(@AuthenticationPrincipal User user) {
+	public RsData<UserInfoResponseDto> userInfo(@CookieValue("accessToken") String accessToken) {
+		String email = tokenProvider.getEmail(accessToken);
+		User user = userService.findUserByEmail(email);
+
 		UserInfoResponseDto targetUser = userService.getUserInfo(user);
 
 		return RsData.success(HttpStatus.OK, targetUser);
@@ -98,15 +100,23 @@ public class UserController {
 	@PutMapping
 	public RsData<UserModifiedResponseDto> update(
 		@RequestBody UserModifiedRequestDto request,
-		@AuthenticationPrincipal User user) {
+		@CookieValue("accessToken") String accessToken) {
+		String email = tokenProvider.getEmail(accessToken);
+		User user = userService.findUserByEmail(email);
+
 		UserModifiedResponseDto response = userService.updateUser(request, user);
 
 		return RsData.success(HttpStatus.OK, response);
 	}
 
 	@DeleteMapping("/resign")
-	public RsData<Void> resign(@AuthenticationPrincipal User user) {
-		userService.deleteUser(user);
+	public RsData<Void> resign(
+		@CookieValue("accessToken") String accessToken,
+		HttpServletResponse response) {
+		String email = tokenProvider.getEmail(accessToken);
+		User user = userService.findUserByEmail(email);
+
+		userService.deleteUser(user, response, accessToken);
 		return RsData.success(HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserModifiedRequestDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserModifiedRequestDto.java
@@ -1,7 +1,5 @@
 package com.ndgl.spotfinder.domain.user.dto;
 
-import com.ndgl.spotfinder.domain.user.entity.User;
-
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -23,11 +21,4 @@ public record UserModifiedRequestDto(
 	)
 	String blogName
 ) {
-	public static UserModifiedRequestDto from(User user) {
-		return new UserModifiedRequestDto(
-			user.getNickName(),
-			user.getBlogName()
-		);
-
-	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserModifiedResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserModifiedResponseDto.java
@@ -1,19 +1,7 @@
 package com.ndgl.spotfinder.domain.user.dto;
 
-import com.ndgl.spotfinder.domain.user.entity.User;
-
 public record UserModifiedResponseDto(
-	Integer code,
-	String message,
 	String nickName,
 	String blogName
 ) {
-	public static UserModifiedResponseDto success(Integer code, String message, User user) {
-		return new UserModifiedResponseDto(
-			code,
-			message,
-			user.getNickName(),
-			user.getBlogName()
-		);
-	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/entity/User.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.ndgl.spotfinder.domain.user.entity;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import com.ndgl.spotfinder.domain.follow.entity.Follow;
 import com.ndgl.spotfinder.global.base.BaseTime;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -56,4 +58,7 @@ public class User extends BaseTime {
 
 	@OneToMany(mappedBy = "followee")
 	private List<Follow> followings;
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Oauth> oauths = new ArrayList<>();
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/service/UserService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/service/UserService.java
@@ -130,15 +130,12 @@ public class UserService {
 
 	@Transactional
 	public UserModifiedResponseDto updateUser(UserModifiedRequestDto request, User user) {
-		User targetUser = findUserByEmail(user.getEmail());
+		user.setNickName(request.nickName());
+		user.setBlogName(request.blogName());
 
-		targetUser.setNickName(request.nickName());
-		targetUser.setBlogName(request.blogName());
-
-		return UserModifiedResponseDto.success(
-			HttpStatus.OK.value(),
-			"OK",
-			targetUser
+		return new UserModifiedResponseDto(
+			request.nickName(),
+			request.blogName()
 		);
 	}
 
@@ -147,8 +144,7 @@ public class UserService {
 		User user,
 		HttpServletResponse response,
 		String accessToken) {
-		User targetUser = findUserByEmail(user.getEmail());
-		userRepository.delete(targetUser);
+		userRepository.delete(user);
 		tokenCookieUtil.cleanTokenCookies(response, accessToken);
 		refreshTokenService.deleteRefreshToken(user.getEmail());
 	}

--- a/src/main/java/com/ndgl/spotfinder/domain/user/service/UserService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/service/UserService.java
@@ -20,7 +20,6 @@ import com.ndgl.spotfinder.domain.user.repository.UserRepository;
 import com.ndgl.spotfinder.global.common.dto.SliceRequest;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
 import com.ndgl.spotfinder.global.security.cookie.TokenCookieUtil;
-import com.ndgl.spotfinder.global.security.redis.repository.RefreshTokenRepository;
 import com.ndgl.spotfinder.global.security.redis.service.RefreshTokenService;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,7 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
 	private final UserRepository userRepository;
 	private final OauthRepository oauthRepository;
-	private final RefreshTokenRepository refreshTokenRepository;
 	private final TokenCookieUtil tokenCookieUtil;
 	private final RefreshTokenService refreshTokenService;
 
@@ -145,8 +143,13 @@ public class UserService {
 	}
 
 	@Transactional
-	public void deleteUser(User user) {
+	public void deleteUser(
+		User user,
+		HttpServletResponse response,
+		String accessToken) {
 		User targetUser = findUserByEmail(user.getEmail());
 		userRepository.delete(targetUser);
+		tokenCookieUtil.cleanTokenCookies(response, accessToken);
+		refreshTokenService.deleteRefreshToken(user.getEmail());
 	}
 }


### PR DESCRIPTION
resolve : #5    

상황 : 

마이페이지 조회, 회원 정보 수정, 회원 탈퇴 기능 접근 시 @AuthenticationPrincipal를 통해 접근을 하다보니 유저 정보를 받아오지 못해 500 에러 이슈 발생. 

대응 : api 호출 시  @AuthenticationPrincipal을 통해 유저 인증을 진행하는 것이 아닌, AccessToken을 받아와 유저 인증 후 마이페이지 접근, 유저 정보 수정, 회원 탈퇴 기능을 진행할 수 있도록 수정. 

※  회원 탈퇴 시 cookie, redis에 등록된 refreshToken 제거 로직 도 누락되어 있어 추가 대응 하였습니다. 
 
