### PR TITLE
댓글 고정 & 검색어 자동완성 기능 추가

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/comment/controller/PostCommentApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/controller/PostCommentApiSpecification.java
@@ -89,4 +89,20 @@ public interface PostCommentApiSpecification {
 		@Parameter(description = "댓글의 ID") Long commentId,
 		@Parameter(hidden = true) Principal principal
 	);
+
+	@Operation(
+		summary = "포스트 댓글 고정",
+		description = "댓글을 고정합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "성공", content = @Content(
+				mediaType = "application/json",
+				examples = @ExampleObject("{\"code\": 200, \"message\": \"OK\"}")
+			))
+		}
+	)
+	RsData<Void> pin(
+		@Parameter(description = "게시물의 ID") Long id,
+		@Parameter(description = "댓글의 ID") Long commentId,
+		@Parameter(hidden = true) Principal principal
+	);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/controller/PostCommentController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/controller/PostCommentController.java
@@ -80,4 +80,14 @@ public class PostCommentController implements PostCommentApiSpecification {
 		postCommentService.delete(id, commentId, principal.getName());
 		return RsData.success(HttpStatus.OK);
 	}
+
+	@PutMapping("/{commentId}/pin")
+	public RsData<Void> pin(
+		@PathVariable Long id,
+		@PathVariable Long commentId,
+		Principal principal
+	) {
+		postCommentService.pinComment(id, commentId, principal.getName());
+		return RsData.success(HttpStatus.OK);
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/dto/PostCommentResponseDto.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
+import com.ndgl.spotfinder.domain.comment.entity.PostCommentStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -16,7 +17,7 @@ public record PostCommentResponseDto(
 	@Schema(description = "댓글 내용", example = "이 포스트 정말 유용하네요!")
 	String content,
 
-	@Schema(description = "작성자 아이디", example = "2")
+	@Schema(description = "작성자 ID", example = "2")
 	Long authorId,
 
 	@Schema(description = "작성자 이름", example = "홍길동")
@@ -30,6 +31,12 @@ public record PostCommentResponseDto(
 
 	@Schema(description = "좋아요 수", example = "50")
 	Long likeCount,
+
+	@Schema(description = "고정 여부", example = "false")
+	Boolean pinned,
+
+	@Schema(description = "댓글 상태", example = "PUBLIC")
+	PostCommentStatus status,
 
 	@Schema(description = "작성 일자", example = "2025-03-23T14:30:00")
 	LocalDateTime createdAt,
@@ -46,12 +53,14 @@ public record PostCommentResponseDto(
 	public PostCommentResponseDto(PostComment comment, Boolean isLiked, List<PostCommentResponseDto> childrenComments) {
 		this(
 			comment.getId(),
-			comment.getContent(),
-			comment.getUser().getId(),
-			comment.getUser().getNickName(),
+			isPublic(comment) ? comment.getContent() : null,
+			isPublic(comment) ? comment.getUser().getId() : null,
+			isPublic(comment) ? comment.getUser().getNickName() : null,
 			comment.getPost().getId(),
-			(comment.getParentComment() != null) ? comment.getParentComment().getId() : null,
-			comment.getLikeCount(),
+			comment.getParentComment() != null ? comment.getParentComment().getId() : null,
+			isPublic(comment) ? comment.getLikeCount() : null,
+			isPublic(comment) ? comment.isPinned() : null,
+			comment.getStatus(),
 			comment.getCreatedAt(),
 			comment.getModifiedAt(),
 			childrenComments,
@@ -61,41 +70,21 @@ public record PostCommentResponseDto(
 
 	public PostCommentResponseDto(PostComment comment, Boolean isLiked) {
 		this(
-			comment.getId(),
-			comment.getContent(),
-			comment.getUser().getId(),
-			comment.getUser().getNickName(),
-			comment.getPost().getId(),
-			(comment.getParentComment() != null) ? comment.getParentComment().getId() : null,
-			comment.getLikeCount(),
-			comment.getCreatedAt(),
-			comment.getModifiedAt(),
+			comment,
+			isLiked,
 			comment.getChildrenComments() == null ? Collections.emptyList()
 				: comment.getChildrenComments().stream()
 				.sorted(Comparator.comparing(PostComment::getId).reversed())
-				.map(PostCommentResponseDto::new)
-				.toList(),
-			isLiked
+				.map(child -> new PostCommentResponseDto(child, false))
+				.toList()
 		);
 	}
 
 	public PostCommentResponseDto(PostComment comment) {
-		this(
-			comment.getId(),
-			comment.getContent(),
-			comment.getUser().getId(),
-			comment.getUser().getNickName(),
-			comment.getPost().getId(),
-			(comment.getParentComment() != null) ? comment.getParentComment().getId() : null,
-			comment.getLikeCount(),
-			comment.getCreatedAt(),
-			comment.getModifiedAt(),
-			comment.getChildrenComments() == null ? Collections.emptyList()
-				: comment.getChildrenComments().stream()
-				.sorted(Comparator.comparing(PostComment::getId).reversed())
-				.map(PostCommentResponseDto::new)
-				.toList(),
-			false
-		);
+		this(comment, false);
+	}
+
+	private static boolean isPublic(PostComment comment) {
+		return comment.getStatus() == PostCommentStatus.PUBLIC;
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
@@ -58,6 +58,11 @@ public class PostComment extends BaseTime implements Likeable {
 	@Column(nullable = false)
 	private Long likeCount;
 
+	@Column(nullable = false)
+	@Builder.Default
+	@Setter
+	private boolean pinned = false;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_id")
 	private PostComment parentComment;

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
@@ -17,6 +17,8 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -62,6 +64,12 @@ public class PostComment extends BaseTime implements Likeable {
 	@Builder.Default
 	@Setter
 	private boolean pinned = false;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	@Builder.Default
+	@Setter
+	private PostCommentStatus status = PostCommentStatus.PUBLIC;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_id")

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostComment.java
@@ -87,13 +87,13 @@ public class PostComment extends BaseTime implements Likeable {
 
 	public void checkAuthorCanModify(User author) {
 		if (!this.user.equals(author)) {
-			ErrorCode.UNAUTHORIZED.throwServiceException();
+			ErrorCode.COMMENT_MODIFY_DENIED.throwServiceException();
 		}
 	}
 
 	public void checkAuthorCanDelete(User author) {
 		if (!this.user.equals(author)) {
-			ErrorCode.UNAUTHORIZED.throwServiceException();
+			ErrorCode.COMMENT_DELETE_DENIED.throwServiceException();
 		}
 	}
 

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostCommentStatus.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/entity/PostCommentStatus.java
@@ -1,0 +1,14 @@
+package com.ndgl.spotfinder.domain.comment.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostCommentStatus {
+	PUBLIC("공개"),
+	DELETED("삭제"),
+	BLINDED("블라인드");
+
+	private final String value;
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/repository/PostCommentRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/repository/PostCommentRepository.java
@@ -1,11 +1,19 @@
 package com.ndgl.spotfinder.domain.comment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
 
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
-	Slice<PostComment> findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
+	Slice<PostComment> findByPostIdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(
+		Long postId, Long lastId, Pageable pageable
+	);
+
+	@Query("SELECT c FROM PostComment c WHERE c.post.id = :postId AND c.pinned = true")
+	Optional<PostComment> findPinnedCommentByPostId(Long postId);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/repository/PostCommentRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/repository/PostCommentRepository.java
@@ -1,5 +1,6 @@
 package com.ndgl.spotfinder.domain.comment.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
@@ -16,4 +17,7 @@ public interface PostCommentRepository extends JpaRepository<PostComment, Long> 
 
 	@Query("SELECT c FROM PostComment c WHERE c.post.id = :postId AND c.pinned = true")
 	Optional<PostComment> findPinnedCommentByPostId(Long postId);
+
+	@Query("SELECT c FROM PostComment c WHERE c.status = 'DELETED' AND c.childrenComments IS EMPTY")
+	List<PostComment> findDeletableComments();
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/scheduler/PostCommentDeleteScheduler.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/scheduler/PostCommentDeleteScheduler.java
@@ -1,0 +1,28 @@
+package com.ndgl.spotfinder.domain.comment.scheduler;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ndgl.spotfinder.domain.comment.entity.PostComment;
+import com.ndgl.spotfinder.domain.comment.repository.PostCommentRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostCommentDeleteScheduler {
+	private final PostCommentRepository postCommentRepository;
+
+	@Scheduled(cron = "0 0 3 * * *")
+	@Transactional
+	public void deleteSoftDeletedComments() {
+		log.info("댓글 삭제 스케줄러 실행");
+		List<PostComment> deletableComments = postCommentRepository.findDeletableComments();
+		postCommentRepository.deleteAll(deletableComments);
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/service/PostCommentService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/service/PostCommentService.java
@@ -164,4 +164,34 @@ public class PostCommentService {
 		return new PostCommentResponseDto(comment, isLiked, childrenComments);
 	}
 
+	@Transactional
+	public void pinComment(Long postId, Long commentId, String email) {
+		Post post = postService.findPostById(postId);
+		User user = userService.findUserByEmail(email);
+
+		// 고정 권한 체크 (작성자만 가능)
+		if (!post.getUser().getId().equals(user.getId())) {
+			ErrorCode.PIN_DENIED.throwServiceException();
+		}
+
+		PostComment targetComment = findCommentById(commentId);
+		targetComment.isCommentOfPost(postId);
+
+		// 기존 고정 댓글 해제
+		Optional<PostComment> existingPinnedCommentOpt = postCommentRepository.findPinnedCommentByPostId(postId);
+		if (existingPinnedCommentOpt.isPresent()) {
+			PostComment existingPinnedComment = existingPinnedCommentOpt.get();
+
+			// 이미 고정된 댓글을 다시 요청한 경우 → 고정 해제
+			if (existingPinnedComment.getId().equals(commentId)) {
+				existingPinnedComment.setPinned(false);
+				return;
+			}
+
+			// 다른 댓글이 고정되어 있는 경우 → 기존 해제 후 대상 고정
+			existingPinnedComment.setPinned(false);
+		}
+
+		targetComment.setPinned(true);
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/comment/service/PostCommentService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/service/PostCommentService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ndgl.spotfinder.domain.comment.dto.PostCommentRequestDto;
 import com.ndgl.spotfinder.domain.comment.dto.PostCommentResponseDto;
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
+import com.ndgl.spotfinder.domain.comment.entity.PostCommentStatus;
 import com.ndgl.spotfinder.domain.comment.repository.PostCommentRepository;
 import com.ndgl.spotfinder.domain.like.entity.Like;
 import com.ndgl.spotfinder.domain.like.service.LikeService;
@@ -95,7 +96,9 @@ public class PostCommentService {
 
 		PostComment comment = findCommentAndVerifyPost(commentId, id);
 		comment.checkAuthorCanDelete(author);
-		postCommentRepository.delete(comment);
+
+		comment.setPinned(false); // 댓글 고정 해제
+		comment.setStatus(PostCommentStatus.DELETED);
 		likeService.deleteAllLikes(commentId, Like.TargetType.COMMENT);
 	}
 

--- a/src/main/java/com/ndgl/spotfinder/domain/report/service/ReportService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/report/service/ReportService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
+import com.ndgl.spotfinder.domain.comment.entity.PostCommentStatus;
 import com.ndgl.spotfinder.domain.comment.service.PostCommentService;
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.service.PostService;
@@ -147,6 +148,9 @@ public class ReportService {
 
 		User user = postCommentReport.getReportedUser();
 		user.setBanned(true);
+
+		PostComment postComment = postCommentReport.getPostComment();
+		postComment.setStatus(PostCommentStatus.BLINDED); // 댓글 블라인드 처리
 
 		Ban ban = Ban.builder()
 			.user(user)

--- a/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchApiSpecification.java
@@ -1,5 +1,7 @@
 package com.ndgl.spotfinder.domain.search.controller;
 
+import java.util.List;
+
 import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
 import com.ndgl.spotfinder.global.common.dto.SliceRequest;
 import com.ndgl.spotfinder.global.common.dto.SliceResponse;
@@ -17,6 +19,14 @@ public interface PostSearchApiSpecification {
 	)
 	RsData<SliceResponse<PostResponseDto>> searchPosts(
 		SliceRequest sliceRequest,
+		@Parameter(description = "검색 키워드") String keyword
+	);
+
+	@Operation(
+		summary = "포스트 검색 자동완성",
+		description = "검색어 자동완성 리스트를 반환합니다."
+	)
+	RsData<List<String>> suggestKeyword(
 		@Parameter(description = "검색 키워드") String keyword
 	);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
@@ -39,4 +39,10 @@ public class PostSearchController implements PostSearchApiSpecification {
 		List<String> results = postSearchService.suggestKeyword(keyword);
 		return RsData.success(HttpStatus.OK, results);
 	}
+
+	@GetMapping("/index")
+	public RsData<String> indexPosts() {
+		postSearchService.indexPosts();
+		return RsData.success(HttpStatus.OK, "인덱싱 완료");
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
@@ -1,5 +1,7 @@
 package com.ndgl.spotfinder.domain.search.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -29,6 +31,12 @@ public class PostSearchController implements PostSearchApiSpecification {
 	) {
 		SliceResponse<PostResponseDto> results = postSearchService.searchPosts(sliceRequest, keyword);
 
+		return RsData.success(HttpStatus.OK, results);
+	}
+
+	@GetMapping("/suggest")
+	public RsData<List<String>> suggestKeyword(@RequestParam String keyword) {
+		List<String> results = postSearchService.suggestKeyword(keyword);
 		return RsData.success(HttpStatus.OK, results);
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/repository/PostSearchRepositoryCustom.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/repository/PostSearchRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.ndgl.spotfinder.domain.search.repository;
 
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +13,6 @@ import com.ndgl.spotfinder.domain.search.document.PostDocument;
 @Repository
 public interface PostSearchRepositoryCustom {
 	Page<PostDocument> searchByKeyword(String keyword, Pageable pageable);
+
+	List<String> suggestKeyword(String keyword);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/repository/PostSearchRepositoryImpl.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/repository/PostSearchRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.ndgl.spotfinder.domain.search.repository;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
@@ -17,6 +20,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.FieldValueFactorModifier;
 import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import lombok.RequiredArgsConstructor;
@@ -83,5 +87,48 @@ public class PostSearchRepositoryImpl implements PostSearchRepositoryCustom {
 		long totalHits = response.hits().total() != null ? response.hits().total().value() : 0;
 
 		return new PageImpl<>(content, pageable, totalHits);
+	}
+
+	@Override
+	public List<String> suggestKeyword(String keyword) {
+		try {
+			SearchResponse<PostDocument> response = elasticsearchClient.search(s -> s
+					.index("post_index")
+					.size(30)
+					.query(q -> q
+						.multiMatch(m -> m
+							.query(keyword)
+							.fields("title", "content", "nickname", "hashtags")
+							.type(TextQueryType.PhrasePrefix) // 검색어 자동완성
+						)
+					),
+				PostDocument.class
+			);
+
+			return response.hits().hits().stream()
+				.map(Hit::source)
+				.filter(Objects::nonNull)
+				.flatMap(doc -> Stream.concat(
+					Stream.of(
+							Optional.ofNullable(doc.getTitle()),
+							Optional.ofNullable(doc.getContent()),
+							Optional.ofNullable(doc.getNickname())
+						)
+						.flatMap(Optional::stream)
+						.filter(s -> !s.isBlank()),
+					doc.getHashtags() != null ? doc.getHashtags().stream() : Stream.empty()
+				))
+				.flatMap(text -> Arrays.stream(text.split("[\\s\\p{Punct}]+")))
+				.map(String::trim)
+				.filter(word -> !word.isBlank())
+				.filter(word -> word.startsWith(keyword))
+				.distinct()
+				.sorted(String::compareTo)
+				.limit(10) // 상위 10개까지 반환
+				.toList();
+
+		} catch (IOException e) {
+			throw ErrorCode.KEYWORD_SUGGESTION_FAIL.throwServiceException(e);
+		}
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -148,5 +149,12 @@ public class PostSearchService {
 		log.info("Redis 캐시 검색 결과 반환 - {}건", results.size());
 
 		return new SliceResponse<>(results, hasNext);
+	}
+
+	@Transactional(readOnly = true)
+	public List<String> suggestKeyword(String keyword) {
+		return Optional.ofNullable(postSearchRepository)
+			.map(repo -> repo.suggestKeyword(keyword))
+			.orElse(Collections.emptyList());
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
@@ -157,4 +157,15 @@ public class PostSearchService {
 			.map(repo -> repo.suggestKeyword(keyword))
 			.orElse(Collections.emptyList());
 	}
+
+	@Transactional(readOnly = true)
+	public void indexPosts() {
+		List<Post> posts = postRepository.findAll();
+		List<PostDocument> documents = posts.stream()
+			.map(PostDocument::from)
+			.toList();
+
+		postSearchRepository.deleteAll();
+		postSearchRepository.saveAll(documents);
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
+++ b/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 
 	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
 	NOT_FOUND_IN_POST(HttpStatus.BAD_REQUEST, "해당 포스트의 댓글이 아닙니다."),
+	PIN_DENIED(HttpStatus.FORBIDDEN, "포스트 작성자만 댓글을 고정할 수 있습니다."),
 
 	// LIKE
 	UNSUPPORTED_TARGET_TYPE(HttpStatus.NOT_FOUND, "지원하지 않는 타겟 유형입니다"),

--- a/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
+++ b/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
@@ -80,6 +80,7 @@ public enum ErrorCode {
 	FOLLOWER_EQUALS_FOLLOWEE(HttpStatus.BAD_REQUEST, "자기 자신은 팔로우, 언팔로우할 수 없습니다."),
 
 	SEARCH_FAIL(HttpStatus.BAD_REQUEST, "엘라스틱서치 검색에 실패했습니다."),
+	KEYWORD_SUGGESTION_FAIL(HttpStatus.BAD_REQUEST, "엘라스틱서치 키워드 추천에 실패했습니다."),
 
 	VIEW_COUNT_KEY_EXTRACT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis Key 추출 중 에러가 발생했습니다.");
 

--- a/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
+++ b/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
@@ -29,7 +29,10 @@ public enum ErrorCode {
 	POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 수정 또는 삭제할 수 있습니다."),
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 포스트입니다."),
 
+	// POST_COMMENT
 	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
+	COMMENT_DELETE_DENIED(HttpStatus.FORBIDDEN, "작성자만 삭제할 수 있습니다."),
+	COMMENT_MODIFY_DENIED(HttpStatus.FORBIDDEN, "작성자만 수정할 수 있습니다."),
 	NOT_FOUND_IN_POST(HttpStatus.BAD_REQUEST, "해당 포스트의 댓글이 아닙니다."),
 	PIN_DENIED(HttpStatus.FORBIDDEN, "포스트 작성자만 댓글을 고정할 수 있습니다."),
 

--- a/src/test/java/com/ndgl/spotfinder/domain/comment/service/PostCommentServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/comment/service/PostCommentServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 import com.ndgl.spotfinder.domain.comment.dto.PostCommentRequestDto;
 import com.ndgl.spotfinder.domain.comment.dto.PostCommentResponseDto;
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
+import com.ndgl.spotfinder.domain.comment.entity.PostCommentStatus;
 import com.ndgl.spotfinder.domain.comment.repository.PostCommentRepository;
 import com.ndgl.spotfinder.domain.like.entity.Like;
 import com.ndgl.spotfinder.domain.like.service.LikeService;
@@ -162,7 +163,8 @@ public class PostCommentServiceTest {
 		// Then
 		verify(postCommentRepository, times(1)).findById(commentId);
 		assert comment != null;
-		verify(postCommentRepository, times(1)).delete(comment);
+		assertEquals(PostCommentStatus.DELETED, comment.getStatus());
+		verify(postCommentRepository, never()).delete(any());
 	}
 
 	@Test

--- a/src/test/java/com/ndgl/spotfinder/domain/comment/service/PostCommentServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/comment/service/PostCommentServiceTest.java
@@ -372,4 +372,55 @@ public class PostCommentServiceTest {
 		verify(likeService, times(1)).getAllLikeStatus(anyLong(), anyList(), any());
 	}
 
+	@Test
+	@DisplayName("댓글 고정")
+	void pinComment_success() {
+		// Given
+		Long postId = 1L;
+		Long commentId = 1L;
+
+		when(postService.findPostById(postId)).thenReturn(post);
+		when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+		when(postCommentRepository.findPinnedCommentByPostId(postId)).thenReturn(Optional.empty());
+		when(postCommentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+		// When
+		postCommentService.pinComment(postId, commentId, user.getEmail());
+
+		// Then
+		assertTrue(comment.isPinned());
+	}
+
+	@Test
+	@DisplayName("포스트 작성자가 아닌 유저가 댓글 고정")
+	void pinComment_unauthorized() {
+		// Given
+		User otherUser = User.builder().id(2L).email("other@test.com").build();
+
+		when(postService.findPostById(post.getId())).thenReturn(post);
+		when(userService.findUserByEmail(otherUser.getEmail())).thenReturn(otherUser);
+
+		// When & Then
+		assertThrows(ServiceException.class, () -> postCommentService.pinComment(
+			1L, 1L, otherUser.getEmail()), "포스트 작성자만 댓글을 고정할 수 있습니다."
+		);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 댓글 고정")
+	void pinComment_NotFound() {
+		// Given
+		Long invalidCommentId = 999L;
+
+		when(postService.findPostById(post.getId())).thenReturn(post);
+		when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+		when(postCommentRepository.findPinnedCommentByPostId(post.getId())).thenReturn(Optional.empty());
+		when(postCommentRepository.findById(invalidCommentId)).thenReturn(Optional.empty());
+
+		// When & Then
+		ServiceException exception = assertThrows(ServiceException.class,
+			() -> postCommentService.pinComment(post.getId(), invalidCommentId, user.getEmail())
+		);
+		assertEquals(HttpStatus.NOT_FOUND, exception.getCode());
+	}
 }

--- a/src/test/java/com/ndgl/spotfinder/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/report/service/ReportServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
+import com.ndgl.spotfinder.domain.comment.entity.PostCommentStatus;
 import com.ndgl.spotfinder.domain.comment.service.PostCommentService;
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.service.PostService;
@@ -419,7 +420,15 @@ public class ReportServiceTest {
 
 		User user = User.builder().id(1L).build();
 
-		PostCommentReport report = PostCommentReport.builder().reportedUser(user).build();
+		PostComment postComment = PostComment.builder()
+			.id(1L)
+			.status(PostCommentStatus.PUBLIC)
+			.build();
+
+		PostCommentReport report = PostCommentReport.builder()
+			.reportedUser(user)
+			.postComment(postComment)
+			.build();
 
 		Ban ban = mock(Ban.class);
 		when(ban.getId()).thenReturn(1L);
@@ -442,6 +451,7 @@ public class ReportServiceTest {
 		assertThat(capturedBan.getEndDate()).isEqualTo(Ban.calculateEndDate(BanDuration.ONE_WEEK));
 		assertThat(capturedBan.getBanType()).isEqualTo(report.getReportType());
 		assertThat(user.isBanned()).isTrue();
+		assertThat(postComment.getStatus()).isEqualTo(PostCommentStatus.BLINDED);
 		assertThat(report.getReportStatus()).isEqualTo(ReportStatus.RESOLVED);
 	}
 

--- a/src/test/java/com/ndgl/spotfinder/domain/search/PostSearchServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/search/PostSearchServiceTest.java
@@ -82,8 +82,8 @@ public class PostSearchServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-		when(valueOperations.get(anyString())).thenReturn(null);
+		lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		lenient().when(valueOperations.get(anyString())).thenReturn(null);
 		postSearchService = new PostSearchService(
 			postService,
 			postRepository,
@@ -157,5 +157,45 @@ public class PostSearchServiceTest {
 
 		verify(postSearchRepository, times(1)).searchByKeyword(eq(keyword), any(PageRequest.class));
 		verify(postRepository, times(1)).findAllById(anyList());
+	}
+
+	@Test
+	@DisplayName("검색어 자동완성")
+	void suggestKeyword() {
+		// given
+		String keyword = "맛";
+		List<String> suggestions = List.of("맛집", "맛있는", "맛있어요");
+		when(postSearchRepository.suggestKeyword(keyword)).thenReturn(suggestions);
+
+		// when
+		List<String> result = postSearchService.suggestKeyword(keyword);
+
+		// then
+		assertNotNull(result);
+		assertEquals(3, result.size());
+		assertTrue(result.contains("맛집"));
+		assertTrue(result.contains("맛있는"));
+		assertTrue(result.contains("맛있어요"));
+
+		// verify
+		verify(postSearchRepository, times(1)).suggestKeyword(keyword);
+	}
+
+	@Test
+	@DisplayName("자동완성 결과가 null -> 빈 리스트 반환")
+	void suggestKeyword_ifNull() {
+		// given
+		String keyword = "맛";
+		when(postSearchRepository.suggestKeyword(keyword)).thenReturn(null);
+
+		// when
+		List<String> result = postSearchService.suggestKeyword(keyword);
+
+		// then
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+
+		// verify
+		verify(postSearchRepository, times(1)).suggestKeyword(keyword);
 	}
 }


### PR DESCRIPTION
## Issue
resolved #131
resolved #132
resolved #134
resolved #162

## 요구 사항과 구현 내용
- 댓글 고정 기능 추가
- 댓글 삭제 방식 soft delete로 개선 -> postcomment 엔티티에 pinned, status 필드를 추가했습니다.
: 댓글 db삭제 스케줄러 도입 -> 대댓글이 존재하지 않고 status == DELETE인 경우 스케줄러가 db에서 삭제
- 검색어 자동완성 기능 추가
