### PR TITLE
Like 타 도메인 Serivce 주입 → Repository, Ut 폴더 이동 

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/comment/controller/PostCommentController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/comment/controller/PostCommentController.java
@@ -19,7 +19,7 @@ import com.ndgl.spotfinder.domain.comment.service.PostCommentService;
 import com.ndgl.spotfinder.global.common.dto.SliceRequest;
 import com.ndgl.spotfinder.global.common.dto.SliceResponse;
 import com.ndgl.spotfinder.global.rsdata.RsData;
-import com.ndgl.spotfinder.global.util.Ut;
+import com.ndgl.spotfinder.global.common.util.CommonUtil;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +37,7 @@ public class PostCommentController implements PostCommentApiSpecification {
 		Principal principal
 	) {
 		return RsData.success(HttpStatus.OK,
-			postCommentService.getComments(Ut.getEmail(principal), id, request.lastId(), request.size())
+			postCommentService.getComments(CommonUtil.getEmail(principal), id, request.lastId(), request.size())
 		);
 	}
 
@@ -47,7 +47,7 @@ public class PostCommentController implements PostCommentApiSpecification {
 		@PathVariable Long commentId,
 		Principal principal
 	) {
-		return RsData.success(HttpStatus.OK, postCommentService.getComment(Ut.getEmail(principal), id, commentId));
+		return RsData.success(HttpStatus.OK, postCommentService.getComment(CommonUtil.getEmail(principal), id, commentId));
 	}
 
 	@PostMapping

--- a/src/main/java/com/ndgl/spotfinder/domain/image/service/ImageService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/image/service/ImageService.java
@@ -16,7 +16,7 @@ import com.ndgl.spotfinder.domain.image.repository.ImageRepository;
 import com.ndgl.spotfinder.domain.image.type.ImageUsage;
 import com.ndgl.spotfinder.global.aws.s3.S3Service;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
-import com.ndgl.spotfinder.global.util.Ut;
+import com.ndgl.spotfinder.global.common.util.CommonUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +46,7 @@ public class ImageService {
 	 */
 	@Transactional
 	public void saveImages(UploadCompleteRequestDto rq) {
-		if (Ut.list.hasValue(rq.imageUrl())) {
+		if (CommonUtil.list.hasValue(rq.imageUrl())) {
 			List<Image> images = rq.imageUrl().stream()
 				.map(url -> Image.builder()
 					.imageUsage(ImageUsage.POST)

--- a/src/main/java/com/ndgl/spotfinder/domain/like/service/LikeService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/like/service/LikeService.java
@@ -6,39 +6,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.ndgl.spotfinder.domain.comment.service.PostCommentService;
+import com.ndgl.spotfinder.domain.comment.repository.PostCommentRepository;
 import com.ndgl.spotfinder.domain.like.entity.Like;
 import com.ndgl.spotfinder.domain.like.entity.Like.TargetType;
 import com.ndgl.spotfinder.domain.like.entity.Likeable;
 import com.ndgl.spotfinder.domain.like.repository.LikeRepository;
-import com.ndgl.spotfinder.domain.post.service.PostService;
+import com.ndgl.spotfinder.domain.post.repository.PostRepository;
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.domain.user.service.UserService;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class LikeService {
 
 	private final LikeRepository likeRepository;
 	private final UserService userService;
-	private final PostService postService;
-	private final PostCommentService postCommentService;
-
-	public LikeService(
-		LikeRepository likeRepository,
-		UserService userService,
-		@Lazy PostService postService,
-		@Lazy PostCommentService postCommentService
-	) {
-		this.likeRepository = likeRepository;
-		this.userService = userService;
-		this.postService = postService;
-		this.postCommentService = postCommentService;
-	}
+	private final PostRepository postRepository;
+	private final PostCommentRepository postCommentRepository;
 
 	/**
 	 * 좋아요 추가 또는 삭제
@@ -133,8 +123,10 @@ public class LikeService {
 
 	private Likeable getTarget(Long targetId, TargetType targetType) {
 		return switch (targetType) {
-			case POST -> postService.findPostById(targetId);
-			case COMMENT -> postCommentService.findCommentById(targetId);
+			case POST -> postRepository.findById(targetId)
+				.orElseThrow(ErrorCode.POST_NOT_FOUND::throwServiceException);
+			case COMMENT -> postCommentRepository.findById(targetId)
+				.orElseThrow(ErrorCode.COMMENT_NOT_FOUND::throwServiceException);
 		};
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
@@ -1,6 +1,6 @@
 package com.ndgl.spotfinder.domain.post.controller;
 
-import static com.ndgl.spotfinder.global.util.Ut.*;
+import static com.ndgl.spotfinder.global.common.util.CommonUtil.*;
 
 import java.security.Principal;
 

--- a/src/main/java/com/ndgl/spotfinder/global/aws/s3/S3Service.java
+++ b/src/main/java/com/ndgl/spotfinder/global/aws/s3/S3Service.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 
 import com.ndgl.spotfinder.domain.image.type.ImageUsage;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
-import com.ndgl.spotfinder.global.util.Ut;
+import com.ndgl.spotfinder.global.common.util.CommonUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,7 +47,7 @@ public class S3Service {
 	 * @return 생성된 Presigned URL 목록
 	 */
 	public List<URL> generatePresignedUrls(ImageUsage imageUsage, long id, List<String> fileExtensions) {
-		if (!Ut.list.hasValue(fileExtensions))
+		if (!CommonUtil.list.hasValue(fileExtensions))
 			return List.of();
 
 		try {
@@ -135,7 +135,7 @@ public class S3Service {
 	 * @param urls url 리스트
 	 */
 	public void deleteObjectsByUrls(List<String> urls) {
-		if (!Ut.list.hasValue(urls))
+		if (!CommonUtil.list.hasValue(urls))
 			return;
 
 		try {

--- a/src/main/java/com/ndgl/spotfinder/global/common/util/CommonUtil.java
+++ b/src/main/java/com/ndgl/spotfinder/global/common/util/CommonUtil.java
@@ -1,10 +1,10 @@
-package com.ndgl.spotfinder.global.util;
+package com.ndgl.spotfinder.global.common.util;
 
 import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 
-public class Ut {
+public class CommonUtil {
 
 	public static class list {
 		public static boolean hasValue(List<?> list) {

--- a/src/test/java/com/ndgl/spotfinder/domain/image/service/ImageCleanupServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/image/service/ImageCleanupServiceTest.java
@@ -29,115 +29,115 @@ import com.ndgl.spotfinder.global.aws.s3.S3Service;
 @ActiveProfiles("test")
 public class ImageCleanupServiceTest {
 
-    @Autowired
-    private ImageCleanupService imageCleanupService;
+	@Autowired
+	private ImageCleanupService imageCleanupService;
 
-    @MockitoBean
-    private ImageRepository imageRepository;
+	@MockitoBean
+	private ImageRepository imageRepository;
 
-    @MockitoBean
-    private S3Service s3Service;
+	@MockitoBean
+	private S3Service s3Service;
 
-    @Captor
-    private ArgumentCaptor<Image> imageCaptor;
+	@Captor
+	private ArgumentCaptor<Image> imageCaptor;
 
-    private List<Image> mockImages;
+	private List<Image> mockImages;
 
-    @BeforeEach
-    void setUp() {
-        Image image1 = Image.builder()
-            .id(1L)
-            .imageUsage(ImageUsage.POST)
-            .referenceId(100L)
-            .url("https://example.com/image1.jpg")
-            .build();
+	@BeforeEach
+	void setUp() {
+		Image image1 = Image.builder()
+			.id(1L)
+			.imageUsage(ImageUsage.POST)
+			.referenceId(100L)
+			.url("https://example.com/image1.jpg")
+			.build();
 
-        Image image2 = Image.builder()
-            .id(2L)
-            .imageUsage(ImageUsage.POST)
-            .referenceId(100L)
-            .url("https://example.com/image2.jpg")
-            .build();
+		Image image2 = Image.builder()
+			.id(2L)
+			.imageUsage(ImageUsage.POST)
+			.referenceId(100L)
+			.url("https://example.com/image2.jpg")
+			.build();
 
-        Image image3 = Image.builder()
-            .id(3L)
-            .imageUsage(ImageUsage.POST)
-            .referenceId(100L)
-            .url("https://example.com/image3.jpg")
-            .build();
+		Image image3 = Image.builder()
+			.id(3L)
+			.imageUsage(ImageUsage.POST)
+			.referenceId(100L)
+			.url("https://example.com/image3.jpg")
+			.build();
 
-        mockImages = Arrays.asList(image1, image2, image3);
+		mockImages = Arrays.asList(image1, image2, image3);
 
-        // Mock 설정
-        when(imageRepository.findByImageUsageAndReferenceId(ImageUsage.POST, 100L))
-                .thenReturn(mockImages);
-    }
+		// Mock 설정
+		when(imageRepository.findByImageUsageAndReferenceId(ImageUsage.POST, 100L))
+			.thenReturn(mockImages);
+	}
 
-    @Test
-    public void testAsyncImageCleanupExecution() {
-        // Given
-        ImageUsage imageUsage = ImageUsage.POST;
-        long referenceId = 100L;
-        
-        // 사용 중인 이미지 URL (image1만 사용 중)
-        Set<String> usedImageUrls = new HashSet<>();
-        usedImageUrls.add("https://example.com/image1.jpg");
+	@Test
+	public void testAsyncImageCleanupExecution() {
+		// Given
+		ImageUsage imageUsage = ImageUsage.POST;
+		long referenceId = 100L;
 
-        // 스레드 이름 확인용 변수
-        final AtomicBoolean asyncExecuted = new AtomicBoolean(false); // 비동기 작업 실행 여부
-        final String[] asyncThreadName = new String[1];
+		// 사용 중인 이미지 URL (image1만 사용 중)
+		Set<String> usedImageUrls = new HashSet<>();
+		usedImageUrls.add("https://example.com/image1.jpg");
 
-        // S3 서비스 모의 설정
-        doAnswer(invocation -> {
-            asyncThreadName[0] = Thread.currentThread().getName();
-            asyncExecuted.set(true);
-            return null;
-        }).when(s3Service).deleteFile(anyString());
+		// 스레드 이름 확인용 변수
+		final AtomicBoolean asyncExecuted = new AtomicBoolean(false); // 비동기 작업 실행 여부
+		final String[] asyncThreadName = new String[1];
 
-        // When
-        System.out.println("메인 스레드: " + Thread.currentThread().getName());
-        imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls);
-        System.out.println("비동기 메서드 호출 직후 - 메인 스레드는 계속 진행");
+		// S3 서비스 모의 설정
+		doAnswer(invocation -> {
+			asyncThreadName[0] = Thread.currentThread().getName();
+			asyncExecuted.set(true);
+			return null;
+		}).when(s3Service).deleteFile(anyString());
 
-        // Then
-        // 1. 비동기 메서드가 다른 스레드에서 실행되는지 확인
-        await().atMost(5, TimeUnit.SECONDS).untilTrue(asyncExecuted);
-        
-        // 2. 다른 스레드에서 실행되었는지 확인
-        System.out.println("비동기 스레드: " + asyncThreadName[0]);
-        assertTrue(asyncThreadName[0].startsWith("ImageClean-"));
-        
-        // 3. 적절한 이미지가 삭제되었는지 확인
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            verify(s3Service, times(2)).deleteFile(anyString());
-            verify(imageRepository, times(2)).delete(imageCaptor.capture());
-            
-            List<Image> deletedImages = imageCaptor.getAllValues();
-            assertEquals(2, deletedImages.size());
-            assertTrue(deletedImages.stream()
-                .anyMatch(img -> img.getUrl().equals("https://example.com/image2.jpg")));
-            assertTrue(deletedImages.stream()
-                .anyMatch(img -> img.getUrl().equals("https://example.com/image3.jpg")));
-        });
-    }
-    
-    @Test
-    public void testAsyncImageCleanupWithException() {
-        // Given
-        ImageUsage imageUsage = ImageUsage.POST;
-        long referenceId = 100L;
-        Set<String> usedImageUrls = new HashSet<>();
-        
-        // S3 서비스가 예외를 던지도록 설정
-        doThrow(new RuntimeException("S3 오류 시뮬레이션")).when(s3Service).deleteFile(anyString());
-        
-        // When (예외가 발생해도 비동기 메서드는 예외를 잡아서 처리)
-        imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls);
-        
-        // Then (메인 스레드는 계속 진행되고, 예외는 로그만 남김)
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            verify(s3Service, times(3)).deleteFile(anyString());
-            // 예외가 발생해도 테스트 실패하지 않음
-        });
-    }
+		// When
+		System.out.println("메인 스레드: " + Thread.currentThread().getName());
+		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls);
+		System.out.println("비동기 메서드 호출 직후 - 메인 스레드는 계속 진행");
+
+		// Then
+		// 1. 비동기 메서드가 다른 스레드에서 실행되는지 확인
+		await().atMost(5, TimeUnit.SECONDS).untilTrue(asyncExecuted);
+
+		// 2. 다른 스레드에서 실행되었는지 확인
+		System.out.println("비동기 스레드: " + asyncThreadName[0]);
+		assertTrue(asyncThreadName[0].startsWith("ImageClean-"));
+
+		// 3. 적절한 이미지가 삭제되었는지 확인
+		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+			verify(s3Service, times(2)).deleteFile(anyString());
+			verify(imageRepository, times(2)).delete(imageCaptor.capture());
+
+			List<Image> deletedImages = imageCaptor.getAllValues();
+			assertEquals(2, deletedImages.size());
+			assertTrue(deletedImages.stream()
+				.anyMatch(img -> img.getUrl().equals("https://example.com/image2.jpg")));
+			assertTrue(deletedImages.stream()
+				.anyMatch(img -> img.getUrl().equals("https://example.com/image3.jpg")));
+		});
+	}
+
+	@Test
+	public void testAsyncImageCleanupWithException() {
+		// Given
+		ImageUsage imageUsage = ImageUsage.POST;
+		long referenceId = 100L;
+		Set<String> usedImageUrls = new HashSet<>();
+
+		// S3 서비스가 예외를 던지도록 설정
+		doThrow(new RuntimeException("S3 오류 시뮬레이션")).when(s3Service).deleteFile(anyString());
+
+		// When (예외가 발생해도 비동기 메서드는 예외를 잡아서 처리)
+		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls);
+
+		// Then (메인 스레드는 계속 진행되고, 예외는 로그만 남김)
+		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+			verify(s3Service, times(3)).deleteFile(anyString());
+			// 예외가 발생해도 테스트 실패하지 않음
+		});
+	}
 } 

--- a/src/test/java/com/ndgl/spotfinder/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/image/service/ImageServiceTest.java
@@ -11,12 +11,12 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.ndgl.spotfinder.domain.image.dto.ImageUrlRequestDto;
 import com.ndgl.spotfinder.domain.image.dto.PresignedUrlsResponseDto;
@@ -25,162 +25,161 @@ import com.ndgl.spotfinder.domain.image.entity.Image;
 import com.ndgl.spotfinder.domain.image.repository.ImageRepository;
 import com.ndgl.spotfinder.domain.image.type.ImageUsage;
 import com.ndgl.spotfinder.global.aws.s3.S3Service;
+import com.ndgl.spotfinder.global.common.util.CommonUtil;
 import com.ndgl.spotfinder.global.exception.ServiceException;
-import com.ndgl.spotfinder.global.util.Ut;
 
-@ActiveProfiles("test")
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class ImageServiceTest {
 
-    @InjectMocks
-    private ImageService imageService;
+	@InjectMocks
+	private ImageService imageService;
 
-    @Mock
-    private ImageRepository imageRepository;
+	@Mock
+	private ImageRepository imageRepository;
 
-    @Mock
-    private S3Service s3Service;
-    
-    // 테스트 이미지 데이터
-    private final Image testImage1 = Image.builder()
-            .id(1L)
-            .imageUsage(ImageUsage.POST)
-            .referenceId(10L)
-            .url("posts/10/image1.jpg")
-            .build();
+	@Mock
+	private S3Service s3Service;
 
-    private final Image testImage2 = Image.builder()
-            .id(2L)
-            .imageUsage(ImageUsage.POST)
-            .referenceId(10L)
-            .url("posts/10/image2.jpg")
-            .build();
+	// 테스트 이미지 데이터
+	private final Image testImage1 = Image.builder()
+		.id(1L)
+		.imageUsage(ImageUsage.POST)
+		.referenceId(10L)
+		.url("posts/10/image1.jpg")
+		.build();
 
-    @Test
-    @DisplayName("Presigned URL 생성 성공")
-    public void createImage_success() throws Exception {
-        // given
-        long postId = 10L;
-        List<String> extensions = Arrays.asList("jpg", "png");
-        ImageUrlRequestDto request = new ImageUrlRequestDto(postId, ImageUsage.POST, extensions);
+	private final Image testImage2 = Image.builder()
+		.id(2L)
+		.imageUsage(ImageUsage.POST)
+		.referenceId(10L)
+		.url("posts/10/image2.jpg")
+		.build();
 
-        List<URL> mockUrls = new ArrayList<>();
-        mockUrls.add(new URL("https://example.com/image1.jpg"));
-        mockUrls.add(new URL("https://example.com/image2.png"));
+	@Test
+	@DisplayName("Presigned URL 생성 성공")
+	public void createImage_success() throws Exception {
+		// given
+		long postId = 10L;
+		List<String> extensions = Arrays.asList("jpg", "png");
+		ImageUrlRequestDto request = new ImageUrlRequestDto(postId, ImageUsage.POST, extensions);
 
-        // when
-        when(s3Service.generatePresignedUrls(ImageUsage.POST, postId, extensions))
-                .thenReturn(mockUrls);
+		List<URL> mockUrls = new ArrayList<>();
+		mockUrls.add(new URL("https://example.com/image1.jpg"));
+		mockUrls.add(new URL("https://example.com/image2.png"));
 
-        PresignedUrlsResponseDto response = imageService.createImage(request);
+		// when
+		when(s3Service.generatePresignedUrls(ImageUsage.POST, postId, extensions))
+			.thenReturn(mockUrls);
 
-        // then
-        assertNotNull(response);
-        assertEquals(2, response.presignedUrls().size());
-        verify(s3Service).generatePresignedUrls(ImageUsage.POST, postId, extensions);
-    }
+		PresignedUrlsResponseDto response = imageService.createImage(request);
 
-    @Test
-    @DisplayName("Presigned URL 생성 실패 - DB 제약조건 위반")
-    public void createImage_dbConstraintViolation() throws Exception {
-        // given
-        long postId = 10L;
-        List<String> extensions = Arrays.asList("jpg", "png");
-        ImageUrlRequestDto request = new ImageUrlRequestDto(postId, ImageUsage.POST, extensions);
+		// then
+		assertNotNull(response);
+		assertEquals(2, response.presignedUrls().size());
+		verify(s3Service).generatePresignedUrls(ImageUsage.POST, postId, extensions);
+	}
 
-        // when
-        when(s3Service.generatePresignedUrls(ImageUsage.POST, postId, extensions))
-                .thenThrow(new DataIntegrityViolationException("DB 제약조건 위반"));
+	@Test
+	@DisplayName("Presigned URL 생성 실패 - DB 제약조건 위반")
+	public void createImage_dbConstraintViolation() throws Exception {
+		// given
+		long postId = 10L;
+		List<String> extensions = Arrays.asList("jpg", "png");
+		ImageUrlRequestDto request = new ImageUrlRequestDto(postId, ImageUsage.POST, extensions);
 
-        // then
-        assertThrows(ServiceException.class, () -> imageService.createImage(request));
-    }
+		// when
+		when(s3Service.generatePresignedUrls(ImageUsage.POST, postId, extensions))
+			.thenThrow(new DataIntegrityViolationException("DB 제약조건 위반"));
 
-    @Test
-    @DisplayName("이미지 저장 성공")
-    public void saveImages_success() {
-        // given
-        long postId = 10L;
-        List<String> imageUrls = Arrays.asList(
-            "posts/10/image1.jpg",
-            "posts/10/image2.jpg"
-        );
-        UploadCompleteRequestDto request = new UploadCompleteRequestDto(postId, ImageUsage.POST, imageUrls);
+		// then
+		assertThrows(ServiceException.class, () -> imageService.createImage(request));
+	}
 
-        // Ut.list.hasValue 모킹 - try-with-resources로 mockStatic 사용
-        try (MockedStatic<Ut.list> mockedList = mockStatic(Ut.list.class)) {
-            mockedList.when(() -> Ut.list.hasValue(imageUrls)).thenReturn(true);
+	@Test
+	@DisplayName("이미지 저장 성공")
+	public void saveImages_success() {
+		// given
+		long postId = 10L;
+		List<String> imageUrls = Arrays.asList(
+			"posts/10/image1.jpg",
+			"posts/10/image2.jpg"
+		);
+		UploadCompleteRequestDto request = new UploadCompleteRequestDto(postId, ImageUsage.POST, imageUrls);
 
-            // when
-            imageService.saveImages(request);
+		// Ut.list.hasValue 모킹 - try-with-resources로 mockStatic 사용
+		try (MockedStatic<CommonUtil.list> mockedList = mockStatic(CommonUtil.list.class)) {
+			mockedList.when(() -> CommonUtil.list.hasValue(imageUrls)).thenReturn(true);
 
-            // then
-            verify(imageRepository).saveAll(anyList());
-        }
-    }
+			// when
+			imageService.saveImages(request);
 
-    @Test
-    @DisplayName("빈 이미지 URL 목록 저장 시 처리")
-    public void saveImages_emptyList() {
-        // given
-        long postId = 10L;
-        List<String> emptyUrls = new ArrayList<>();
-        UploadCompleteRequestDto request = new UploadCompleteRequestDto(postId, ImageUsage.POST, emptyUrls);
+			// then
+			verify(imageRepository).saveAll(anyList());
+		}
+	}
 
-        // Ut.list.hasValue 모킹 - try-with-resources로 mockStatic 사용
-        try (MockedStatic<Ut.list> mockedList = mockStatic(Ut.list.class)) {
-            mockedList.when(() -> Ut.list.hasValue(emptyUrls)).thenReturn(false);
+	@Test
+	@DisplayName("빈 이미지 URL 목록 저장 시 처리")
+	public void saveImages_emptyList() {
+		// given
+		long postId = 10L;
+		List<String> emptyUrls = new ArrayList<>();
+		UploadCompleteRequestDto request = new UploadCompleteRequestDto(postId, ImageUsage.POST, emptyUrls);
 
-            // when
-            imageService.saveImages(request);
+		// Ut.list.hasValue 모킹 - try-with-resources로 mockStatic 사용
+		try (MockedStatic<CommonUtil.list> mockedList = mockStatic(CommonUtil.list.class)) {
+			mockedList.when(() -> CommonUtil.list.hasValue(emptyUrls)).thenReturn(false);
 
-            // then
-            verify(imageRepository, never()).saveAll(anyList());
-        }
-    }
+			// when
+			imageService.saveImages(request);
 
-    @Test
-    @DisplayName("단일 이미지 삭제 성공")
-    public void deleteImageByUrl_success() {
-        // given
-        String imageUrl = "posts/10/image1.jpg";
+			// then
+			verify(imageRepository, never()).saveAll(anyList());
+		}
+	}
 
-        // when
-        when(imageRepository.findByUrl(imageUrl)).thenReturn(Optional.of(testImage1));
+	@Test
+	@DisplayName("단일 이미지 삭제 성공")
+	public void deleteImageByUrl_success() {
+		// given
+		String imageUrl = "posts/10/image1.jpg";
 
-        imageService.deleteImageByUrl(imageUrl);
+		// when
+		when(imageRepository.findByUrl(imageUrl)).thenReturn(Optional.of(testImage1));
 
-        // then
-        verify(s3Service).deleteFile(imageUrl);
-        verify(imageRepository).delete(testImage1);
-    }
+		imageService.deleteImageByUrl(imageUrl);
 
-    @Test
-    @DisplayName("존재하지 않는 이미지 URL 삭제 시도")
-    public void deleteImageByUrl_notFound() {
-        // given
-        String nonExistingUrl = "posts/999/notfound.jpg";
+		// then
+		verify(s3Service).deleteFile(imageUrl);
+		verify(imageRepository).delete(testImage1);
+	}
 
-        // when
-        when(imageRepository.findByUrl(nonExistingUrl)).thenReturn(Optional.empty());
+	@Test
+	@DisplayName("존재하지 않는 이미지 URL 삭제 시도")
+	public void deleteImageByUrl_notFound() {
+		// given
+		String nonExistingUrl = "posts/999/notfound.jpg";
 
-        imageService.deleteImageByUrl(nonExistingUrl);
+		// when
+		when(imageRepository.findByUrl(nonExistingUrl)).thenReturn(Optional.empty());
 
-        // then
-        verify(s3Service).deleteFile(nonExistingUrl);
-        verify(imageRepository, never()).delete(any(Image.class));
-    }
+		imageService.deleteImageByUrl(nonExistingUrl);
 
-    @Test
-    @DisplayName("모든 이미지 삭제 성공")
-    public void deletePostWithAllImages_success() {
-        // given
-        long postId = 10L;
+		// then
+		verify(s3Service).deleteFile(nonExistingUrl);
+		verify(imageRepository, never()).delete(any(Image.class));
+	}
 
-        // when
-        imageService.deletePostWithAllImages(ImageUsage.POST, postId);
+	@Test
+	@DisplayName("모든 이미지 삭제 성공")
+	public void deletePostWithAllImages_success() {
+		// given
+		long postId = 10L;
 
-        // then
-        verify(imageRepository).deleteAllByImageUsageAndReferenceId(ImageUsage.POST, postId);
-    }
+		// when
+		imageService.deletePostWithAllImages(ImageUsage.POST, postId);
+
+		// then
+		verify(imageRepository).deleteAllByImageUsageAndReferenceId(ImageUsage.POST, postId);
+	}
 }

--- a/src/test/java/com/ndgl/spotfinder/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/like/service/LikeServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -12,92 +13,88 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
-import com.ndgl.spotfinder.domain.comment.service.PostCommentService;
+import com.ndgl.spotfinder.domain.comment.repository.PostCommentRepository;
 import com.ndgl.spotfinder.domain.like.entity.Like;
 import com.ndgl.spotfinder.domain.like.entity.Like.TargetType;
 import com.ndgl.spotfinder.domain.like.repository.LikeRepository;
 import com.ndgl.spotfinder.domain.post.entity.Post;
-import com.ndgl.spotfinder.domain.post.service.PostService;
+import com.ndgl.spotfinder.domain.post.repository.PostRepository;
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.domain.user.service.UserService;
+import com.ndgl.spotfinder.global.exception.ServiceException;
 
-@ActiveProfiles("test")
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class LikeServiceTest {
 
 	@Mock
 	private LikeRepository likeRepository;
 
 	@Mock
-	private PostService postService;
+	private PostRepository postRepository;
 
 	@Mock
-	private PostCommentService postCommentService;
+	private PostCommentRepository postCommentRepository;
 
 	@Mock
 	private UserService userService;
-	
+
+	@InjectMocks
 	private LikeService likeService;
 
-	// 공통 테스트 상수 및 객체
 	private final long VALID_USER_ID = 1L;
 	private final String VALID_USER_EMAIL = "test@example.com";
 	private final long VALID_POST_ID = 10L;
 	private final long VALID_COMMENT_ID = 20L;
-	private final long INVALID_TARGET_ID = -1L;
 
-	private final User testUser = User.builder()
-		.id(VALID_USER_ID)
-		.email("test@example.com")
-		.nickName("테스트유저")
-		.blogName("테스트블로그")
-		.build();
+	private User testUser;
+	private Like postLike;
+	private Like commentLike;
+	private Post mockPostEntity;
+	private PostComment mockCommentEntity;
 
-	private final Like postLike = Like.builder()
-		.id(1L)
-		.user(testUser)
-		.targetId(VALID_POST_ID)
-		.targetType(TargetType.POST)
-		.build();
-
-	private final Like commentLike = Like.builder()
-		.id(2L)
-		.user(testUser)
-		.targetId(VALID_COMMENT_ID)
-		.targetType(TargetType.COMMENT)
-		.build();
-	
-	private Post mockPost;
-	private PostComment mockComment;
-	
 	@BeforeEach
 	public void setup() {
-		// @Lazy 어노테이션을 사용하므로 수동으로 생성자 주입
-		likeService = new LikeService(likeRepository, userService, postService, postCommentService);
-		
-		// Mock 객체 설정
-		mockPost = mock(Post.class);
-		mockComment = mock(PostComment.class);
-		
-		// PostService와 PostCommentService 모킹
-		when(postService.findPostById(VALID_POST_ID)).thenReturn(mockPost);
-		when(postCommentService.findCommentById(VALID_COMMENT_ID)).thenReturn(mockComment);
+		// 테스트 객체 초기화
+		testUser = User.builder()
+			.id(VALID_USER_ID)
+			.email(VALID_USER_EMAIL)
+			.nickName("테스트유저")
+			.blogName("테스트블로그")
+			.build();
+
+		postLike = Like.builder()
+			.id(1L)
+			.user(testUser)
+			.targetId(VALID_POST_ID)
+			.targetType(TargetType.POST)
+			.build();
+
+		commentLike = Like.builder()
+			.id(2L)
+			.user(testUser)
+			.targetId(VALID_COMMENT_ID)
+			.targetType(TargetType.COMMENT)
+			.build();
+
+		mockPostEntity = mock(Post.class);
+		mockCommentEntity = mock(PostComment.class);
 	}
 
 	@Test
 	@DisplayName("포스트 좋아요 추가 성공")
 	public void toggleLike_addPostLike_success() {
-		// given: 좋아요가 아직 존재하지 않음
+		// given
 		when(userService.findUserByEmail(VALID_USER_EMAIL)).thenReturn(testUser);
-		when(userService.findUserById(VALID_USER_ID)).thenReturn(testUser);
 		when(likeRepository.findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID, TargetType.POST))
 			.thenReturn(Optional.empty());
 		when(likeRepository.save(any(Like.class))).thenReturn(postLike);
+		when(postRepository.findById(VALID_POST_ID)).thenReturn(Optional.of(mockPostEntity));
 
 		// when
 		boolean result = likeService.toggleLike(VALID_USER_EMAIL, VALID_POST_ID, TargetType.POST);
@@ -107,17 +104,18 @@ public class LikeServiceTest {
 		verify(userService).findUserByEmail(VALID_USER_EMAIL);
 		verify(likeRepository).findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID, TargetType.POST);
 		verify(likeRepository).save(any(Like.class));
-		verify(mockPost).addLike();
-		verify(postService).findPostById(VALID_POST_ID);
+		verify(postRepository).findById(VALID_POST_ID);
+		verify(mockPostEntity).addLike();
 	}
 
 	@Test
 	@DisplayName("포스트 좋아요 취소 성공")
 	public void toggleLike_removePostLike_success() {
-		// given: 좋아요가 이미 존재함
+		// given
 		when(userService.findUserByEmail(VALID_USER_EMAIL)).thenReturn(testUser);
 		when(likeRepository.findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID, TargetType.POST))
 			.thenReturn(Optional.of(postLike));
+		when(postRepository.findById(VALID_POST_ID)).thenReturn(Optional.of(mockPostEntity));
 
 		// when
 		boolean result = likeService.toggleLike(VALID_USER_EMAIL, VALID_POST_ID, TargetType.POST);
@@ -127,20 +125,19 @@ public class LikeServiceTest {
 		verify(userService).findUserByEmail(VALID_USER_EMAIL);
 		verify(likeRepository).findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID, TargetType.POST);
 		verify(likeRepository).delete(postLike);
-		verify(mockPost).removeLike();
-		verify(postService).findPostById(VALID_POST_ID);
+		verify(postRepository).findById(VALID_POST_ID);
+		verify(mockPostEntity).removeLike();
 	}
 
 	@Test
 	@DisplayName("댓글 좋아요 추가 성공")
 	public void toggleLike_addCommentLike_success() {
-		// given: 좋아요가 아직 존재하지 않음 (댓글)
+		// given
 		when(userService.findUserByEmail(VALID_USER_EMAIL)).thenReturn(testUser);
-		when(userService.findUserById(VALID_USER_ID)).thenReturn(testUser);
-		when(likeRepository.findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
-			TargetType.COMMENT))
+		when(likeRepository.findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT))
 			.thenReturn(Optional.empty());
 		when(likeRepository.save(any(Like.class))).thenReturn(commentLike);
+		when(postCommentRepository.findById(VALID_COMMENT_ID)).thenReturn(Optional.of(mockCommentEntity));
 
 		// when
 		boolean result = likeService.toggleLike(VALID_USER_EMAIL, VALID_COMMENT_ID, TargetType.COMMENT);
@@ -151,18 +148,18 @@ public class LikeServiceTest {
 		verify(likeRepository).findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
 			TargetType.COMMENT);
 		verify(likeRepository).save(any(Like.class));
-		verify(mockComment).addLike();
-		verify(postCommentService).findCommentById(VALID_COMMENT_ID);
+		verify(postCommentRepository).findById(VALID_COMMENT_ID);
+		verify(mockCommentEntity).addLike();
 	}
 
 	@Test
 	@DisplayName("댓글 좋아요 취소 성공")
 	public void toggleLike_removeCommentLike_success() {
-		// given: 좋아요가 이미 존재함 (댓글)
+		// given
 		when(userService.findUserByEmail(VALID_USER_EMAIL)).thenReturn(testUser);
-		when(likeRepository.findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
-			TargetType.COMMENT))
+		when(likeRepository.findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT))
 			.thenReturn(Optional.of(commentLike));
+		when(postCommentRepository.findById(VALID_COMMENT_ID)).thenReturn(Optional.of(mockCommentEntity));
 
 		// when
 		boolean result = likeService.toggleLike(VALID_USER_EMAIL, VALID_COMMENT_ID, TargetType.COMMENT);
@@ -173,8 +170,19 @@ public class LikeServiceTest {
 		verify(likeRepository).findByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
 			TargetType.COMMENT);
 		verify(likeRepository).delete(commentLike);
-		verify(mockComment).removeLike();
-		verify(postCommentService).findCommentById(VALID_COMMENT_ID);
+		verify(postCommentRepository).findById(VALID_COMMENT_ID);
+		verify(mockCommentEntity).removeLike();
+	}
+
+	@Test
+	@DisplayName("이메일이 null일 때 좋아요 추가 실패")
+	public void toggleLike_nullEmail_throwsException() {
+		// when & then
+		assertThrows(ServiceException.class, () -> {
+			likeService.toggleLike(null, VALID_POST_ID, TargetType.POST);
+		});
+		verify(userService, never()).findUserByEmail(anyString());
+		verify(likeRepository, never()).findByUserIdAndTargetIdAndTargetType(anyLong(), anyLong(), any());
 	}
 
 	@Test
@@ -186,13 +194,13 @@ public class LikeServiceTest {
 			Like.builder().user(testUser).targetId(1L).targetType(TargetType.POST).build(),
 			Like.builder().user(testUser).targetId(3L).targetType(TargetType.POST).build()
 		);
-		
+
 		when(likeRepository.findAllByUserIdAndTargetIdInAndTargetType(
 			VALID_USER_ID, postIds, TargetType.POST)).thenReturn(likes);
-			
+
 		// when
 		Map<Long, Boolean> result = likeService.getAllLikeStatus(VALID_USER_ID, postIds, TargetType.POST);
-		
+
 		// then
 		assertEquals(3, result.size());
 		assertTrue(result.get(1L));  // 좋아요 있음
@@ -203,27 +211,52 @@ public class LikeServiceTest {
 	}
 
 	@Test
+	@DisplayName("빈 게시물 ID 리스트로 좋아요 상태 조회시 빈 맵 반환")
+	public void getAllLikeStatus_emptyList_returnsEmptyMap() {
+		// given
+		List<Long> emptyPostIds = Collections.emptyList();
+
+		// when
+		Map<Long, Boolean> result = likeService.getAllLikeStatus(VALID_USER_ID, emptyPostIds, TargetType.POST);
+
+		// then
+		assertTrue(result.isEmpty());
+		verify(likeRepository, never()).findAllByUserIdAndTargetIdInAndTargetType(
+			anyLong(), anyList(), any(TargetType.class));
+	}
+
+	@Test
 	@DisplayName("포스트의 모든 좋아요 삭제 성공")
 	public void deleteAllLikes_forPost_success() {
+		// when
 		likeService.deleteAllLikes(VALID_POST_ID, TargetType.POST);
+
+		// then
 		verify(likeRepository).deleteByTargetIdAndTargetType(VALID_POST_ID, TargetType.POST);
 	}
 
 	@Test
 	@DisplayName("댓글의 모든 좋아요 삭제 성공")
 	public void deleteAllLikes_forComment_success() {
+		// when
 		likeService.deleteAllLikes(VALID_COMMENT_ID, TargetType.COMMENT);
+
+		// then
 		verify(likeRepository).deleteByTargetIdAndTargetType(VALID_COMMENT_ID, TargetType.COMMENT);
 	}
 
 	@Test
 	@DisplayName("포스트 좋아요 수 조회 성공")
 	public void getLikeCount_forPost_success() {
+		// given
 		long expectedCount = 5L;
 		when(likeRepository.countByTargetIdAndTargetType(VALID_POST_ID, TargetType.POST))
 			.thenReturn(expectedCount);
 
+		// when
 		Long result = likeService.getLikeCount(VALID_POST_ID, TargetType.POST);
+
+		// then
 		assertEquals(expectedCount, result);
 		verify(likeRepository).countByTargetIdAndTargetType(VALID_POST_ID, TargetType.POST);
 	}
@@ -231,11 +264,15 @@ public class LikeServiceTest {
 	@Test
 	@DisplayName("댓글 좋아요 수 조회 성공")
 	public void getLikeCount_forComment_success() {
+		// given
 		long expectedCount = 3L;
 		when(likeRepository.countByTargetIdAndTargetType(VALID_COMMENT_ID, TargetType.COMMENT))
 			.thenReturn(expectedCount);
 
+		// when
 		Long result = likeService.getLikeCount(VALID_COMMENT_ID, TargetType.COMMENT);
+
+		// then
 		assertEquals(expectedCount, result);
 		verify(likeRepository).countByTargetIdAndTargetType(VALID_COMMENT_ID, TargetType.COMMENT);
 	}
@@ -243,59 +280,76 @@ public class LikeServiceTest {
 	@Test
 	@DisplayName("포스트 좋아요 상태 조회 - 좋아요가 존재함")
 	public void getLikeStatus_forPost_exists() {
-		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID, TargetType.POST))
-			.thenReturn(true);
+		// given
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_POST_ID, TargetType.POST)).thenReturn(true);
 
+		// when
 		Boolean result = likeService.getLikeStatus(VALID_USER_ID, VALID_POST_ID, TargetType.POST);
+
+		// then
 		assertTrue(result);
-		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID,
-			TargetType.POST);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_POST_ID, TargetType.POST);
 	}
 
 	@Test
 	@DisplayName("포스트 좋아요 상태 조회 - 좋아요 없음")
 	public void getLikeStatus_forPost_notExists() {
-		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID, TargetType.POST))
-			.thenReturn(false);
+		// given
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_POST_ID, TargetType.POST)).thenReturn(false);
 
+		// when
 		Boolean result = likeService.getLikeStatus(VALID_USER_ID, VALID_POST_ID, TargetType.POST);
+
+		// then
 		assertFalse(result);
-		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_POST_ID,
-			TargetType.POST);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_POST_ID, TargetType.POST);
 	}
 
 	@Test
 	@DisplayName("댓글 좋아요 상태 조회 - 좋아요가 존재함")
 	public void getLikeStatus_forComment_exists() {
-		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
-			TargetType.COMMENT))
-			.thenReturn(true);
+		// given
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT)).thenReturn(true);
 
+		// when
 		Boolean result = likeService.getLikeStatus(VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT);
+
+		// then
 		assertTrue(result);
-		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
-			TargetType.COMMENT);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT);
 	}
 
 	@Test
 	@DisplayName("댓글 좋아요 상태 조회 - 좋아요 없음")
 	public void getLikeStatus_forComment_notExists() {
-		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
-			TargetType.COMMENT))
-			.thenReturn(false);
+		// given
+		when(likeRepository.existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT)).thenReturn(false);
 
+		// when
 		Boolean result = likeService.getLikeStatus(VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT);
+
+		// then
 		assertFalse(result);
-		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(VALID_USER_ID, VALID_COMMENT_ID,
-			TargetType.COMMENT);
+		verify(likeRepository).existsByUserIdAndTargetIdAndTargetType(
+			VALID_USER_ID, VALID_COMMENT_ID, TargetType.COMMENT);
 	}
 
 	@Test
 	@DisplayName("userId가 null인 경우 좋아요 상태 조회 - false 반환")
 	public void getLikeStatus_userIdNull_returnsFalse() {
+		// when
 		Boolean result = likeService.getLikeStatus(null, VALID_POST_ID, TargetType.POST);
-		assertFalse(result);
-		verify(likeRepository, never()).existsByUserIdAndTargetIdAndTargetType(anyLong(), anyLong(), any());
-	}
 
+		// then
+		assertFalse(result);
+		verify(likeRepository, never()).existsByUserIdAndTargetIdAndTargetType(
+			anyLong(), anyLong(), any(TargetType.class));
+	}
 }


### PR DESCRIPTION
## Issue
resolved #184 
resolved #185 

## 요구 사항과 구현 내용
- Ut.java를 global/common 에 CommonUtil.java로 이동시켰습니다.
- LikeService에서 타 도메인의 Service 주입를 Repository로 변경했습니다
  - 변경이유는 Service의 메서드가 크게 필요하지 않고, 기초 SELECT만 필요하므로 Repository로 변경하게 되었습니다.