### PR TITLE
인기 게시물 목록 캐싱 효율화, 인기 검색어 / 게시물 사이즈 통일, 변경 로직에 맞게 테스트 수정

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/popular/constants/PopularConstants.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/popular/constants/PopularConstants.java
@@ -1,0 +1,8 @@
+package com.ndgl.spotfinder.domain.popular.constants;
+
+public final class PopularConstants {
+	private  PopularConstants(){}
+
+	public static final int KEYWORD_COUNT = 10;
+	public static final int POST_COUNT = 10;
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/popular/scheduler/PopularTrendsScheduler.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/popular/scheduler/PopularTrendsScheduler.java
@@ -3,6 +3,7 @@ package com.ndgl.spotfinder.domain.popular.scheduler;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.ndgl.spotfinder.domain.popular.dto.KeywordCountDto;
@@ -10,6 +11,7 @@ import com.ndgl.spotfinder.domain.popular.dto.PostCountDto;
 import com.ndgl.spotfinder.domain.popular.service.PopularService;
 import com.ndgl.spotfinder.domain.popular.service.elasticsearch.ElasticsearchPopularService;
 import com.ndgl.spotfinder.domain.popular.service.redis.RedisPopularService;
+import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,12 +21,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PopularTrendsScheduler {
 
-	private static final int TOP_SIZE = 10;
 	private final ElasticsearchPopularService elasticsearchPopularService;
 	private final RedisPopularService redisPopularService;
 	private final PopularService popularService;
 
-	// @Scheduled(cron = "0 */30 * * * *") // 매 30분 간격으로 실행
+	@Scheduled(cron = "0 */30 * * * *") // 매 30분 간격으로 실행
 	public void updatePopularTrends() {
 		log.info("인기 검색어 및 게시물 업데이트 스케줄러 시작: {}", LocalDateTime.now());
 
@@ -33,8 +34,8 @@ public class PopularTrendsScheduler {
 			long startTime = endTime - (30 * 60 * 1000);
 
 			// Elasticsearch 에서 인기 검색어 / 인기 포스트 조회
-			List<KeywordCountDto> topKeywords = elasticsearchPopularService.findTopKeywords(startTime, endTime, TOP_SIZE);
-			List<PostCountDto> topPosts = elasticsearchPopularService.findTopPosts(startTime, endTime, TOP_SIZE);
+			List<KeywordCountDto> topKeywords = elasticsearchPopularService.findTopKeywords(startTime, endTime);
+			List<PostCountDto> topPosts = elasticsearchPopularService.findTopPosts(startTime, endTime);
 
 			// 레디스 업데이트
 			redisPopularService.updateRedisPopularKeywords(topKeywords);
@@ -46,17 +47,17 @@ public class PopularTrendsScheduler {
 
 			// 레디스 조회
 			// TODO: 안정화되면 지워야 함
-			List<KeywordCountDto> keywordCountDtos = redisPopularService.getPopularKeywords(10);
-			List<PostCountDto> postCountDtos = redisPopularService.getPopularPosts(10);
+			List<String> keywords = redisPopularService.getPopularKeywords();
+			List<PostResponseDto> posts = redisPopularService.getPopularPosts();
 
-			for(int i = 0; i< keywordCountDtos.size(); i++) {
-				log.info("{}위 - 인기 검색어 : {} -{}",
-					i+1, keywordCountDtos.get(i).keyword(), keywordCountDtos.get(i).count());
+			for(int i = 0; i< keywords.size(); i++) {
+				log.info("{}위 - 인기 검색어 : {}",
+					i+1, keywords.get(i));
 			}
 
-			for(int i = 0; i< postCountDtos.size(); i++) {
-				log.info("{}위 - 인기 게시물 : {} -{}",
-					i+1, postCountDtos.get(i).postId(), postCountDtos.get(i).count());
+			for(int i = 0; i< posts.size(); i++) {
+				log.info("{}위 - 인기 게시물 : {}",
+					i+1, posts.get(i).id());
 			}
 
 			log.info("인기 검색어 및 게시물 업데이트 완료");

--- a/src/main/java/com/ndgl/spotfinder/domain/popular/service/elasticsearch/ElasticsearchPopularService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/popular/service/elasticsearch/ElasticsearchPopularService.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.ndgl.spotfinder.domain.popular.constants.PopularConstants;
 import com.ndgl.spotfinder.domain.popular.dto.KeywordCountDto;
 import com.ndgl.spotfinder.domain.popular.dto.PostCountDto;
 import com.ndgl.spotfinder.global.app.AppConfig;
@@ -43,7 +44,7 @@ public class ElasticsearchPopularService {
 
 
 	// 인기 검색어 Top N 조회
-	public List<KeywordCountDto> findTopKeywords(long startTime, long endTime, int size) throws IOException {
+	public List<KeywordCountDto> findTopKeywords(long startTime, long endTime) throws IOException {
 		String[] indices = getIndicesForTimeRange(startTime, endTime, keywordSearchIndex);
 
 		for (String index : indices) {
@@ -66,7 +67,7 @@ public class ElasticsearchPopularService {
 				.aggregations("top_keywords", a -> a
 					.terms(t -> t
 						.field("keyword.joined")
-						.size(size)
+						.size(PopularConstants.KEYWORD_COUNT)
 					)
 				)
 				.size(0), // 집계 결과만 필요하므로 검색 결과는 불필요
@@ -86,7 +87,7 @@ public class ElasticsearchPopularService {
 	}
 
 	// 인기 포스트 Top N 조회
-	public List<PostCountDto> findTopPosts(long startTime, long endTime, int size) throws IOException {
+	public List<PostCountDto> findTopPosts(long startTime, long endTime) throws IOException {
 		String[] indices = getIndicesForTimeRange(startTime, endTime, postViewIndex);
 
 		for (String index : indices) {
@@ -109,7 +110,7 @@ public class ElasticsearchPopularService {
 				.aggregations("top_posts", a -> a
 					.terms(t -> t
 						.field("postId")
-						.size(size)
+						.size(PopularConstants.POST_COUNT)
 					)
 				)
 				.size(0), // 집계 결과만 필요하므로 검색 결과는 불필요

--- a/src/main/java/com/ndgl/spotfinder/domain/popular/service/redis/RedisPopularService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/popular/service/redis/RedisPopularService.java
@@ -3,13 +3,19 @@ package com.ndgl.spotfinder.domain.popular.service.redis;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ndgl.spotfinder.domain.popular.constants.PopularConstants;
 import com.ndgl.spotfinder.domain.popular.dto.KeywordCountDto;
 import com.ndgl.spotfinder.domain.popular.dto.PostCountDto;
+import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
+import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.domain.post.repository.PostRepository;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -20,104 +26,117 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RedisPopularService {
 
-	@Qualifier("redisTemplate")
+	private final PostRepository postRepository;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+
 	private static final String POPULAR_KEYWORDS_KEY = "popular:keywords";
 	private static final String POPULAR_POSTS_KEY = "popular:posts";
 
 	// Top N 키워드 순서대로 저장
-	public void updateRedisPopularKeywords(List<KeywordCountDto> keywords) {
+	public void updateRedisPopularKeywords(List<KeywordCountDto> keywordCounts) {
 		ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
 
 		// 기존 ZSET 데이터 삭제
-		redisTemplate.delete(POPULAR_KEYWORDS_KEY);
-
-		// 새로운 데이터 추가
-		for (KeywordCountDto keyword : keywords) {
-			zSetOps.add(POPULAR_KEYWORDS_KEY, keyword.keyword(), keyword.count());
+		if(!keywordCounts.isEmpty()) {
+			redisTemplate.delete(POPULAR_KEYWORDS_KEY);
 		}
 
-		log.info("Redis 인기 검색어 업데이트 완료: {} 개 키워드", keywords.size());
+		// 새로운 데이터 추가
+		for (KeywordCountDto keywordCount : keywordCounts) {
+			zSetOps.add(POPULAR_KEYWORDS_KEY, keywordCount.keyword(), keywordCount.count());
+		}
+
+		log.info("Redis 인기 검색어 업데이트 완료: {} 개 키워드", keywordCounts.size());
 	}
 
 	// Top N 포스트 순서대로 저장
-	public void updateRedisPopularPosts(List<PostCountDto> posts) {
-		ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+	@Transactional(readOnly = true)
+	public void updateRedisPopularPosts(List<PostCountDto> postCounts) {
+		try {
+			ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
 
-		// 기존 ZSET 데이터 삭제
-		redisTemplate.delete(POPULAR_POSTS_KEY);
+			// 기존 ZSET 데이터 삭제
+			if(!postCounts.isEmpty()) {
+				redisTemplate.delete(POPULAR_POSTS_KEY);
+			}
 
-		// 새로운 데이터 추가
-		for (PostCountDto post : posts) {
-			zSetOps.add(POPULAR_POSTS_KEY, String.valueOf(post.postId()), post.count());
+			// 새로운 데이터 추가
+			for (PostCountDto postCount : postCounts) {
+				Post post = postRepository.findById(postCount.postId())
+					.orElseThrow(ErrorCode.POST_NOT_FOUND::throwServiceException);
+				PostResponseDto postResponseDto = new PostResponseDto(post);
+				zSetOps.add(POPULAR_POSTS_KEY, objectMapper.writeValueAsString(postResponseDto), postCount.count());
+			}
+
+			log.info("Redis 인기 게시물 업데이트 완료: {} 개 게시물", postCounts.size());
+		} catch (JsonProcessingException e){
+			ErrorCode.JSON_PROCESSING_EXCEPTION.throwServiceException(e);
 		}
-
-		log.info("Redis 인기 게시물 업데이트 완료: {} 개 게시물", posts.size());
 	}
 
 	// Top N 인기 검색어 조회
-	public List<KeywordCountDto> getPopularKeywords(int size) {
+	public List<String> getPopularKeywords() {
 		ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
 
 		// ZSET에서 상위 N개 항목 조회 (내림차순, 0부터 N-1까지)
-		Set<ZSetOperations.TypedTuple<String>> keywordSet = zSetOps.reverseRangeWithScores(POPULAR_KEYWORDS_KEY, 0, size-1);
+		Set<ZSetOperations.TypedTuple<String>> keywordSet = zSetOps.reverseRangeWithScores(POPULAR_KEYWORDS_KEY, 0, PopularConstants.KEYWORD_COUNT-1);
 
 		if (keywordSet == null || keywordSet.isEmpty()) {
 			ErrorCode.POPULAR_KEYWORD_NOT_FOUND.throwServiceException();
 		}
 
 		// KeywordCount 리스트로 변환
-		List<KeywordCountDto> result = keywordSet.stream()
-			.map(this::toKeywordCountDto)
+		List<String> popularKeywords = keywordSet.stream()
+			.map(this::toKeyword)
 			.toList();
 
-		log.info("Redis에서 인기 검색어 Top 10 조회 완료: {} 개", result.size());
-		return result;
+		log.info("Redis에서 인기 검색어 Top 10 조회 완료: {} 개", popularKeywords.size());
+
+		return popularKeywords;
 	}
 
 	// Top N 인기 게시물 조회
-	public List<PostCountDto> getPopularPosts(int size) {
+	public List<PostResponseDto> getPopularPosts() {
 		ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
 
 		// ZSET에서 상위 N개 항목 조회 (내림차순, 0부터 N-1까지)
-		Set<ZSetOperations.TypedTuple<String>> postSet = zSetOps.reverseRangeWithScores(POPULAR_POSTS_KEY, 0, size-1);
+		Set<ZSetOperations.TypedTuple<String>> postSet = zSetOps.reverseRangeWithScores(POPULAR_POSTS_KEY, 0, PopularConstants.POST_COUNT-1);
 
 		if (postSet == null || postSet.isEmpty()) {
 			ErrorCode.POPULAR_POST_NOT_FOUND.throwServiceException();
 		}
 
-		// PostCount 리스트로 변환
-		List<PostCountDto> result = postSet.stream()
-			.map(this::toPostCountDto)
+		// PostId 리스트로 변환
+		List<PostResponseDto> popularPosts = postSet.stream()
+			.map(this::toPostResponseDto)
 			.toList();
 
-		log.info("Redis에서 인기 게시물 Top 10 조회 완료: {} 개", result.size());
-		return result;
+		log.info("Redis에서 인기 게시물 Top 10 조회 완료: {} 개", popularPosts.size());
+
+		return popularPosts;
+	}
+
+	private String toKeyword(ZSetOperations.TypedTuple<String> tuple) {
+		if(isInvalidTuple(tuple))
+			ErrorCode.REDIS_INVALID_ZSET_TUPLE.throwServiceException();
+
+		return tuple.getValue();
+	}
+
+	private PostResponseDto toPostResponseDto(ZSetOperations.TypedTuple<String> tuple) {
+		try {
+			if (isInvalidTuple(tuple))
+				ErrorCode.REDIS_INVALID_ZSET_TUPLE.throwServiceException();
+
+			return objectMapper.readValue(tuple.getValue(), PostResponseDto.class);
+		} catch(JsonProcessingException e) {
+			throw ErrorCode.JSON_PROCESSING_EXCEPTION.throwServiceException(e);
+		}
 	}
 
 	private boolean isInvalidTuple(ZSetOperations.TypedTuple<String> tuple) {
 		return tuple == null || tuple.getValue() == null || tuple.getScore() == null;
-	}
-
-	private KeywordCountDto toKeywordCountDto(ZSetOperations.TypedTuple<String> tuple) {
-		if(isInvalidTuple(tuple))
-			ErrorCode.REDIS_INVALID_ZSET_TUPLE.throwServiceException();
-
-		String keyword = tuple.getValue();
-		long score = tuple.getScore().longValue();
-		return new KeywordCountDto(keyword, score);
-	}
-
-	private PostCountDto toPostCountDto(ZSetOperations.TypedTuple<String> tuple) {
-		if(isInvalidTuple(tuple))
-			ErrorCode.REDIS_INVALID_ZSET_TUPLE.throwServiceException();
-
-		try {
-			long postId = Long.parseLong(tuple.getValue());
-			long score = tuple.getScore().longValue();
-			return new PostCountDto(postId, score);
-		} catch(NumberFormatException e) {
-			throw ErrorCode.REDIS_INVALID_ZSET_TUPLE.throwServiceException(e);
-		}
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostApiSpecification.java
@@ -1,6 +1,7 @@
 package com.ndgl.spotfinder.domain.post.controller;
 
 import java.security.Principal;
+import java.util.List;
 
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -132,4 +133,9 @@ public interface PostApiSpecification {
 		SliceRequest sliceRequest,
 		@Parameter(hidden = true) Principal principal
 	);
+
+	@Operation(
+		summary = "인기 포스트 1~6위 조회"
+	)
+	RsData<List<PostResponseDto>> getPopularPosts();
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.ndgl.spotfinder.domain.post.controller;
 import static com.ndgl.spotfinder.global.common.util.CommonUtil.*;
 
 import java.security.Principal;
+import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -133,5 +134,10 @@ public class PostController implements PostApiSpecification {
 		SliceResponse<PostResponseDto> results = postService.getPostsByFollow(sliceRequest, principal.getName());
 
 		return RsData.success(HttpStatus.OK, results);
+	}
+
+	@GetMapping("/popular")
+	public RsData<List<PostResponseDto>> getPopularPosts() {
+		return RsData.success(HttpStatus.OK, postService.getPopularPosts());
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/controller/PostController.java
@@ -138,6 +138,7 @@ public class PostController implements PostApiSpecification {
 
 	@GetMapping("/popular")
 	public RsData<List<PostResponseDto>> getPopularPosts() {
-		return RsData.success(HttpStatus.OK, postService.getPopularPosts());
+		List<PostResponseDto> popularPosts = postService.getPopularPosts();
+		return RsData.success(HttpStatus.OK, popularPosts);
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -17,6 +17,7 @@ import com.ndgl.spotfinder.domain.image.service.ImageService;
 import com.ndgl.spotfinder.domain.image.type.ImageUsage;
 import com.ndgl.spotfinder.domain.like.entity.Like;
 import com.ndgl.spotfinder.domain.like.service.LikeService;
+import com.ndgl.spotfinder.domain.popular.service.redis.RedisPopularService;
 import com.ndgl.spotfinder.domain.post.dto.PostCommonUpdateRequestDto;
 import com.ndgl.spotfinder.domain.post.dto.PostCreateRequestDto;
 import com.ndgl.spotfinder.domain.post.dto.PostDetailResponseDto;
@@ -43,6 +44,7 @@ public class PostService {
 	private final UserService userService;
 	private final ImageCleanupService imageCleanupService;
 	private final LikeService likeService;
+	private final RedisPopularService redisPopularService;
 
 	private static final int FIRST_PAGE_NUMBER = 0;
 	private static final Long DEFAULT_LAST_ID = 0L;
@@ -200,5 +202,9 @@ public class PostService {
 			urls.add(markdownMatcher.group(1));
 		}
 		return urls;
+	}
+
+	public List<PostResponseDto> getPopularPosts() {
+		return redisPopularService.getPopularPosts();
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/controller/PostSearchController.java
@@ -45,4 +45,11 @@ public class PostSearchController implements PostSearchApiSpecification {
 		postSearchService.indexPosts();
 		return RsData.success(HttpStatus.OK, "인덱싱 완료");
 	}
+
+	@GetMapping("/popular-keywords")
+	public RsData<List<String>> getPopularKeywords() {
+		List<String> popularKeywords = postSearchService.getPopularKeywords();
+		return RsData.success(HttpStatus.OK, popularKeywords);
+	}
+
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/search/service/PostSearchService.java
@@ -19,6 +19,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ndgl.spotfinder.domain.popular.service.redis.RedisPopularService;
 import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.repository.PostRepository;
@@ -39,6 +40,7 @@ public class PostSearchService {
 	private final PostRepository postRepository;
 	private final ElasticsearchHealthCheck healthCheck;
 	private final PostSearchRepository postSearchRepository;
+	private final RedisPopularService redisPopularService;
 
 	@Qualifier("postCachdRedisTemplate")
 	private final RedisTemplate<String, List<Long>> redisTemplate;
@@ -48,13 +50,15 @@ public class PostSearchService {
 		PostRepository postJpaRepository,
 		ElasticsearchHealthCheck healthCheck,
 		@Autowired(required = false) PostSearchRepository postSearchRepository,
-		RedisTemplate<String, List<Long>> redisTemplate
+		RedisTemplate<String, List<Long>> redisTemplate,
+		RedisPopularService redisPopularService
 	) {
 		this.postService = postService;
 		this.postRepository = postJpaRepository;
 		this.healthCheck = healthCheck;
 		this.postSearchRepository = postSearchRepository;
 		this.redisTemplate = redisTemplate;
+		this.redisPopularService = redisPopularService;
 	}
 
 	@Transactional(readOnly = true)
@@ -167,5 +171,9 @@ public class PostSearchService {
 
 		postSearchRepository.deleteAll();
 		postSearchRepository.saveAll(documents);
+	}
+
+	public List<String> getPopularKeywords() {
+		return redisPopularService.getPopularKeywords();
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/global/elk/ElasticsearchIndexingScheduler.java
+++ b/src/main/java/com/ndgl/spotfinder/global/elk/ElasticsearchIndexingScheduler.java
@@ -35,7 +35,7 @@ public class ElasticsearchIndexingScheduler {
 		postSearchRepository.saveAll(documents);
 	}
 
-	// @Scheduled(cron = "0 */30 * * * *") // 30분마다 부분 색인
+	@Scheduled(cron = "0 */30 * * * *") // 30분마다 부분 색인
 	public void partialReindexPosts() {
 		log.info("부분 인덱싱 수행");
 		LocalDateTime thirtyMinutesAgo = LocalDateTime.now().minusMinutes(30);

--- a/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
+++ b/src/main/java/com/ndgl/spotfinder/global/exception/ErrorCode.java
@@ -82,7 +82,9 @@ public enum ErrorCode {
 	SEARCH_FAIL(HttpStatus.BAD_REQUEST, "엘라스틱서치 검색에 실패했습니다."),
 	KEYWORD_SUGGESTION_FAIL(HttpStatus.BAD_REQUEST, "엘라스틱서치 키워드 추천에 실패했습니다."),
 
-	VIEW_COUNT_KEY_EXTRACT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis Key 추출 중 에러가 발생했습니다.");
+	VIEW_COUNT_KEY_EXTRACT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis Key 추출 중 에러가 발생했습니다."),
+
+	JSON_PROCESSING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "ObjectMapper 변환 도중 에러가 발생했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/test/java/com/ndgl/spotfinder/domain/popular/elasticsearch/ElasticsearchPopularServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/popular/elasticsearch/ElasticsearchPopularServiceTest.java
@@ -35,7 +35,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 
 @ExtendWith(MockitoExtension.class)
-class ElasticsearchServiceTest {
+class ElasticsearchPopularServiceTest {
 
 	@Mock
 	private AppConfig appConfig;
@@ -69,7 +69,7 @@ class ElasticsearchServiceTest {
 		when(elasticsearchClient.search(any(Function.class), eq(Void.class))).thenReturn(mockResponse);
 
 		// when
-		List<KeywordCountDto> result = elasticsearchPopularService.findTopKeywords(startTime, endTime, size);
+		List<KeywordCountDto> result = elasticsearchPopularService.findTopKeywords(startTime, endTime);
 
 		// then
 		assertThat(result).hasSize(3);
@@ -94,7 +94,7 @@ class ElasticsearchServiceTest {
 		when(elasticsearchClient.search(any(Function.class), eq(Void.class))).thenReturn(mockResponse);
 
 		// when.
-		List<PostCountDto> result = elasticsearchPopularService.findTopPosts(startTime, endTime, size);
+		List<PostCountDto> result = elasticsearchPopularService.findTopPosts(startTime, endTime);
 
 		// then
 		assertThat(result).hasSize(3);

--- a/src/test/java/com/ndgl/spotfinder/domain/popular/redis/RedisPopularServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/popular/redis/RedisPopularServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,9 +20,18 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.http.HttpStatus;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ndgl.spotfinder.domain.popular.constants.PopularConstants;
 import com.ndgl.spotfinder.domain.popular.dto.KeywordCountDto;
 import com.ndgl.spotfinder.domain.popular.dto.PostCountDto;
 import com.ndgl.spotfinder.domain.popular.service.redis.RedisPopularService;
+import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
+import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.domain.post.entity.PostStatus;
+import com.ndgl.spotfinder.domain.post.repository.PostRepository;
+import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
 import com.ndgl.spotfinder.global.exception.ServiceException;
 
@@ -29,10 +39,18 @@ import com.ndgl.spotfinder.global.exception.ServiceException;
 class RedisPopularServiceTest {
 
 	@Mock
-	private RedisTemplate redisTemplate;
+	private RedisTemplate<String, String> redisTemplate;
 
 	@Mock
 	private ZSetOperations<String, String> zSetOps;
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@Mock
+	private PostRepository postRepository;
+
+	private final ObjectMapper realObjectMapper = new ObjectMapper();
 
 	@InjectMocks
 	private RedisPopularService redisPopularService;
@@ -63,18 +81,49 @@ class RedisPopularServiceTest {
 
 	@Test
 	@DisplayName("레디스 인기 게시물 갱신 - 정상")
-	void 정상_레디스_인기_게시물_갱신(){
+	void 정상_레디스_인기_게시물_갱신() throws Exception{
 		// Given
+		User user = mock(User.class);
+		when(user.getId()).thenReturn(1L);
+		when(user.getNickName()).thenReturn("test");
+
+		Post post1 = Post.builder()
+			.id(1L)
+			.title("테스트1")
+			.content("테스트 내용1")
+			.user(user)
+			.thumbnail("https://example.com/" + user.getId() + "_thumbnail.jpg")
+			.viewCount(10L)
+			.likeCount(0L)
+			.status(PostStatus.PUBLIC)
+			.build();
+
+		Post post2 = Post.builder()
+			.id(2L)
+			.title("테스트2")
+			.content("테스트 내용2")
+			.user(user)
+			.thumbnail("https://example.com/" + user.getId() + "_thumbnail.jpg")
+			.viewCount(10L)
+			.likeCount(0L)
+			.status(PostStatus.PUBLIC)
+			.build();
+
 		List<PostCountDto> postCountDtos = List.of(
-			new PostCountDto(1L, 50L),
-			new PostCountDto(2L, 100L)
+			new PostCountDto(post1.getId(), 50L),
+			new PostCountDto(post2.getId(), 100L)
 		);
 
+		when(postRepository.findById(post1.getId())).thenReturn(Optional.of(post1));
+		when(postRepository.findById(post2.getId())).thenReturn(Optional.of(post2));
+
+		// When
 		redisPopularService.updateRedisPopularPosts(postCountDtos);
 
+		// Then
 		verify(redisTemplate).delete(POPULAR_POSTS_KEY);
-		verify(zSetOps).add(eq(POPULAR_POSTS_KEY), eq("1"), eq(50.0));
-		verify(zSetOps).add(eq(POPULAR_POSTS_KEY), eq("2"), eq(100.0));
+		verify(zSetOps).add(eq(POPULAR_POSTS_KEY), any(), eq(50.0));
+		verify(zSetOps).add(eq(POPULAR_POSTS_KEY), any(), eq(100.0));
 	}
 
 	@Test
@@ -87,14 +136,12 @@ class RedisPopularServiceTest {
 		when(zSetOps.reverseRangeWithScores(POPULAR_KEYWORDS_KEY, 0, 9)).thenReturn(mockSet);
 
 		//when
-		List<KeywordCountDto> result = redisPopularService.getPopularKeywords(10);
+		List<String> result = redisPopularService.getPopularKeywords();
 
 		//then
 		assertThat(result).hasSize(2);
-		assertThat(result.get(0).keyword()).isEqualTo("키워드1");
-		assertThat(result.get(0).count()).isEqualTo(100L);
-		assertThat(result.get(1).keyword()).isEqualTo("키워드2");
-		assertThat(result.get(1).count()).isEqualTo(50L);
+		assertThat(result.get(0)).isEqualTo("키워드1");
+		assertThat(result.get(1)).isEqualTo("키워드2");
 	}
 
 	@Test
@@ -104,7 +151,7 @@ class RedisPopularServiceTest {
 		when(zSetOps.reverseRangeWithScores(POPULAR_KEYWORDS_KEY, 0, 9)).thenReturn(Collections.emptySet());
 
 		// When & Then
-		assertThatThrownBy(() -> redisPopularService.getPopularKeywords(10))
+		assertThatThrownBy(() -> redisPopularService.getPopularKeywords())
 			.isInstanceOf(ServiceException.class)
 			.satisfies(exception -> {
 				ServiceException serviceException = (ServiceException) exception;
@@ -122,7 +169,7 @@ class RedisPopularServiceTest {
 		when(zSetOps.reverseRangeWithScores(POPULAR_KEYWORDS_KEY, 0, 9)).thenReturn(mockSet);
 
 		// When & Then
-		assertThatThrownBy(() -> redisPopularService.getPopularKeywords(10))
+		assertThatThrownBy(() -> redisPopularService.getPopularKeywords())
 			.isInstanceOf(ServiceException.class)
 			.satisfies(exception -> {
 				ServiceException serviceException = (ServiceException) exception;
@@ -133,22 +180,54 @@ class RedisPopularServiceTest {
 
 	@Test
 	@DisplayName("Top N 인기 게시물 조회 - 정상")
-	void 정상_Top_N개_인기_게시물_조회() {
+	void 정상_Top_N개_인기_게시물_조회() throws Exception {
 		Set<ZSetOperations.TypedTuple<String>> mockSet = new LinkedHashSet<>();
-		mockSet.add(mockTypedTuple("1", 100.0));
-		mockSet.add(mockTypedTuple("2", 50.0));
 
-		when(zSetOps.reverseRangeWithScores(POPULAR_POSTS_KEY, 0, 9)).thenReturn(mockSet);
+		User user = mock(User.class);
+		when(user.getId()).thenReturn(1L);
+		when(user.getNickName()).thenReturn("test");
+
+		Post post1 = Post.builder()
+			.id(1L)
+			.title("테스트1")
+			.content("테스트 내용1")
+			.user(user)
+			.thumbnail("https://example.com/" + user.getId() + "_thumbnail.jpg")
+			.viewCount(10L)
+			.likeCount(0L)
+			.status(PostStatus.PUBLIC)
+			.build();
+
+		Post post2 = Post.builder()
+			.id(2L)
+			.title("테스트2")
+			.content("테스트 내용2")
+			.user(user)
+			.thumbnail("https://example.com/" + user.getId() + "_thumbnail.jpg")
+			.viewCount(10L)
+			.likeCount(0L)
+			.status(PostStatus.PUBLIC)
+			.build();
+		PostResponseDto postDto1 = new PostResponseDto(post1);
+		PostResponseDto postDto2 = new PostResponseDto(post2);
+
+		String postJson1 = realObjectMapper.writeValueAsString(postDto1);
+		String postJson2 = realObjectMapper.writeValueAsString(postDto2);
+
+		mockSet.add(mockTypedTuple(postJson1, 100.0));
+		mockSet.add(mockTypedTuple(postJson2, 50.0));
+
+		when(zSetOps.reverseRangeWithScores(POPULAR_POSTS_KEY, 0, PopularConstants.POST_COUNT-1)).thenReturn(mockSet);
+		when(objectMapper.readValue(postJson1, PostResponseDto.class)).thenReturn(postDto1);
+		when(objectMapper.readValue(postJson2, PostResponseDto.class)).thenReturn(postDto2);
 
 		//when
-		List<PostCountDto> result = redisPopularService.getPopularPosts(10);
+		List<PostResponseDto> result = redisPopularService.getPopularPosts();
 
 		//then
 		assertThat(result).hasSize(2);
-		assertThat(result.get(0).postId()).isEqualTo(1);
-		assertThat(result.get(0).count()).isEqualTo(100L);
-		assertThat(result.get(1).postId()).isEqualTo(2);
-		assertThat(result.get(1).count()).isEqualTo(50L);
+		assertThat(result.get(0).id()).isEqualTo(1);
+		assertThat(result.get(1).id()).isEqualTo(2);
 	}
 
 	@Test
@@ -158,7 +237,7 @@ class RedisPopularServiceTest {
 		when(zSetOps.reverseRangeWithScores(POPULAR_POSTS_KEY, 0, 9)).thenReturn(Collections.emptySet());
 
 		// When & Then
-		assertThatThrownBy(() -> redisPopularService.getPopularPosts(10))
+		assertThatThrownBy(() -> redisPopularService.getPopularPosts())
 			.isInstanceOf(ServiceException.class)
 			.satisfies(exception -> {
 				ServiceException serviceException = (ServiceException) exception;
@@ -176,7 +255,7 @@ class RedisPopularServiceTest {
 		when(zSetOps.reverseRangeWithScores(POPULAR_POSTS_KEY, 0, 9)).thenReturn(mockSet);
 
 		// When & Then
-		assertThatThrownBy(() -> redisPopularService.getPopularPosts(10))
+		assertThatThrownBy(() -> redisPopularService.getPopularPosts())
 			.isInstanceOf(ServiceException.class)
 			.satisfies(exception -> {
 				ServiceException serviceException = (ServiceException) exception;
@@ -187,20 +266,23 @@ class RedisPopularServiceTest {
 
 	@Test
 	@DisplayName("Top N 인기 게시물 조회 - key 가 숫자가 아닌 Tuple")
-	void 비정상_Top_N개_인기_게시물_조회_숫자가_아닌_value_를_가진_튜플() {
+	void 비정상_Top_N개_인기_게시물_조회_숫자가_아닌_value_를_가진_튜플() throws Exception{
 		Set<ZSetOperations.TypedTuple<String>> mockSet = new LinkedHashSet<>();
-		mockSet.add(mockTypedTuple("invalid", 100.0));
+		String invalidJson = "invalid";
+		mockSet.add(mockTypedTuple(invalidJson, 100.0));
 
 		when(zSetOps.reverseRangeWithScores(POPULAR_POSTS_KEY, 0, 9)).thenReturn(mockSet);
+		when(objectMapper.readValue(invalidJson, PostResponseDto.class))
+			.thenThrow(new JsonMappingException(null, "invalid Json"));
 
 		// When & Then
-		assertThatThrownBy(() -> redisPopularService.getPopularPosts(10))
+		assertThatThrownBy(() -> redisPopularService.getPopularPosts())
 			.isInstanceOf(ServiceException.class)
 			.satisfies(exception -> {
 				ServiceException serviceException = (ServiceException) exception;
 				assertThat(serviceException.getCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-				assertThat(serviceException.getMessage()).isEqualTo(ErrorCode.REDIS_INVALID_ZSET_TUPLE.getMessage());
-				assertThat(serviceException.getCause()).isInstanceOf(NumberFormatException.class);
+				assertThat(serviceException.getMessage()).isEqualTo(ErrorCode.JSON_PROCESSING_EXCEPTION.getMessage());
+				assertThat(serviceException.getCause()).isInstanceOf(JsonProcessingException.class);
 			});
 	}
 
@@ -211,3 +293,4 @@ class RedisPopularServiceTest {
 		return tuple;
 	}
 }
+

--- a/src/test/java/com/ndgl/spotfinder/domain/search/PostSearchServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/search/PostSearchServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.ndgl.spotfinder.domain.popular.service.redis.RedisPopularService;
 import com.ndgl.spotfinder.domain.post.dto.PostResponseDto;
 import com.ndgl.spotfinder.domain.post.entity.Post;
 import com.ndgl.spotfinder.domain.post.repository.PostRepository;
@@ -59,6 +60,10 @@ public class PostSearchServiceTest {
 	@Mock
 	private ElasticsearchHealthCheck healthCheck;
 
+	@Mock
+	private RedisPopularService redisPopularService;
+
+
 	private final User user1 = User.builder()
 		.id(1L)
 		.email("이메일1")
@@ -89,7 +94,8 @@ public class PostSearchServiceTest {
 			postRepository,
 			healthCheck,
 			postSearchRepository,
-			redisTemplate
+			redisTemplate,
+			redisPopularService
 		);
 	}
 


### PR DESCRIPTION
## 해결된 Issue
resolves #190 
resolves #191 
resolves #194 

### 구현 내용
1. 인기 검색어 / 게시물의 사이즈를 PopularConstants 클래스의 상수를 활용하도록 통합
2. 레디스에서 인기 게시물 조회 시, postId 를 반환하지 않고 PostResponseDto 반환하도록 수정하여 캐싱 효율 개선
3. 인기 게시물 목록 획득 API 구현
4. 인기 검색어 목록 획득 API 구현
5. ErrorCode 에 ObjectMapper 관련 예외 추가
6. 개선된 PopularService 클래스들의 로직에 맞게 테스트 동작하도록 수정