### PR TITLE
포스트 및 해시태그 조회 로직 수정, Redis 사용하는 코드 수정, 포스트 목록의 내용 가공해서 표시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ dependencies {
     // 비동기 테스트
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
+    // Jsoup
+    implementation 'org.jsoup:jsoup:1.14.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostResponseDto.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.global.common.util.MarkdownUtil;
+import com.ndgl.spotfinder.global.common.util.StringUtil;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -39,12 +41,13 @@ public record PostResponseDto(
 	List<HashtagDto> hashtags
 ) {
 	private static final Long POST_LIST_HASHTAG_COUNT = 3L;
+	private static final Integer SLICED_CONTENT_LENGTH = 200;
 
 	public PostResponseDto(Post post) {
 		this(
 			post.getId(),
 			post.getTitle(),
-			post.getContent(),
+			sliceAndRemoveNewLinesFromContent(post.getContent()),
 			post.getUser().getId(),
 			post.getUser().getNickName(),
 			post.getThumbnail(),
@@ -59,4 +62,11 @@ public record PostResponseDto(
 		);
 	}
 
+	private static String sliceAndRemoveNewLinesFromContent(String content) {
+		String slicedContent =
+			content.length() > SLICED_CONTENT_LENGTH ? content.substring(0, SLICED_CONTENT_LENGTH) : content;
+		String pureText = MarkdownUtil.extractTextFromMarkdown(slicedContent);
+
+		return StringUtil.removeNewLines(pureText);
+	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostViewCountDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/dto/PostViewCountDto.java
@@ -1,0 +1,11 @@
+package com.ndgl.spotfinder.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostViewCountDto {
+	private Long postId;
+	private Long viewCount;
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/entity/Post.java
@@ -4,13 +4,11 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import com.ndgl.spotfinder.domain.comment.entity.PostComment;
 import com.ndgl.spotfinder.domain.like.entity.Likeable;
-import com.ndgl.spotfinder.domain.post.dto.HashtagDto;
-import com.ndgl.spotfinder.domain.post.dto.LocationDto;
-import com.ndgl.spotfinder.domain.post.dto.PostCommonUpdateRequestDto;
 import com.ndgl.spotfinder.domain.user.entity.User;
 import com.ndgl.spotfinder.global.base.BaseTime;
 
@@ -71,6 +69,7 @@ public class Post extends BaseTime implements Likeable {
 	private List<PostComment> comments = new ArrayList<>();
 
 	@Builder.Default
+	@BatchSize(size = 50)
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Hashtag> hashtags = new ArrayList<>();
 
@@ -109,27 +108,6 @@ public class Post extends BaseTime implements Likeable {
 
 	public void addLocations(List<Location> locations) {
 		locations.forEach(this::addLocation);
-	}
-
-	public Post updatePost(PostCommonUpdateRequestDto requestDto, boolean temp) {
-		title = requestDto.title();
-		content = requestDto.content();
-		thumbnail = requestDto.thumbnail();
-		this.status = temp ? PostStatus.TEMP : PostStatus.PUBLIC;
-
-		List<Hashtag> newHashtags = requestDto.hashtags()
-			.stream()
-			.map(HashtagDto::toHashtag)
-			.toList();
-		updateHashtags(newHashtags);
-
-		List<Location> newLocations = requestDto.locations()
-			.stream()
-			.map(LocationDto::toLocation)
-			.toList();
-		updateLocations(newLocations);
-
-		return this;
 	}
 
 	public void updateHashtags(List<Hashtag> newHashtags) {

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -1,7 +1,6 @@
 package com.ndgl.spotfinder.domain.post.repository;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,15 +18,15 @@ import com.ndgl.spotfinder.domain.user.entity.User;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 	@EntityGraph(attributePaths = {"hashtags"})
-	Slice<Post> findByIdLessThanOrderByCreatedAtDesc(Long lastId, PageRequest pageRequest);
+	Slice<Post> findByIdLessThanOrderByIdDesc(Long lastId, PageRequest pageRequest);
 
 	@EntityGraph(attributePaths = {"hashtags"})
-	Slice<Post> findByUserAndIdLessThanOrderByCreatedAtDesc(User user, Long lastId, PageRequest pageRequest);
+	Slice<Post> findByUserAndIdLessThanOrderByIdDesc(User user, Long lastId, PageRequest pageRequest);
 
 	@Query("SELECT p FROM Post p " +
 		   "JOIN Like l ON p.id = l.targetId AND l.targetType = 'POST' " +
 		   "WHERE l.user.id = :userId AND p.id < :lastId " +
-		   "ORDER BY p.createdAt DESC")
+		   "ORDER BY p.id DESC")
 	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findLikedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
 		PageRequest pageRequest);
@@ -35,7 +34,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	@Query("SELECT p FROM Post p " +
 		   "JOIN Follow f ON f.follower.id = :userId AND f.followee.id = p.user.id " +
 		   "WHERE p.id < :lastId " +
-		   "ORDER BY p.createdAt DESC")
+		   "ORDER BY p.id DESC")
 	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findFollowedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
 		PageRequest pageRequest);
@@ -49,7 +48,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		   + "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) "
 		   + "OR LOWER(p.user.nickName) LIKE LOWER(CONCAT('%', :keyword, '%')) "
 		   + "OR EXISTS (SELECT h FROM p.hashtags h WHERE LOWER(h.name) LIKE LOWER(CONCAT('%', :keyword, '%')))) "
-		   + "ORDER BY p.createdAt DESC")
+		   + "ORDER BY p.id DESC")
 	Slice<Post> searchAll(String keyword, PageRequest pageRequest);
 
 	List<Post> findByUser(User user);
@@ -63,8 +62,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		   + "JOIN FETCH p.user LEFT JOIN FETCH p.hashtags "
 		   + "WHERE p.updatedAt > :updatedAt")
 	List<Post> findByUpdatedAtAfter(LocalDateTime updatedAt);
-
-	List<Post> findByIdIn(Collection<Long> ids);
 
 	@Modifying
 	@Query("UPDATE Post p SET p.viewCount = p.viewCount + :count WHERE p.id = :postId")

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,17 +16,14 @@ import com.ndgl.spotfinder.domain.post.entity.PostStatus;
 import com.ndgl.spotfinder.domain.user.entity.User;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findByIdLessThanOrderByIdDesc(Long lastId, PageRequest pageRequest);
 
-	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findByUserAndIdLessThanOrderByIdDesc(User user, Long lastId, PageRequest pageRequest);
 
 	@Query("SELECT p FROM Post p " +
 		   "JOIN Like l ON p.id = l.targetId AND l.targetType = 'POST' " +
 		   "WHERE l.user.id = :userId AND p.id < :lastId " +
 		   "ORDER BY p.id DESC")
-	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findLikedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
 		PageRequest pageRequest);
 
@@ -35,7 +31,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		   "JOIN Follow f ON f.follower.id = :userId AND f.followee.id = p.user.id " +
 		   "WHERE p.id < :lastId " +
 		   "ORDER BY p.id DESC")
-	@EntityGraph(attributePaths = {"hashtags"})
 	Slice<Post> findFollowedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
 		PageRequest pageRequest);
 

--- a/src/main/java/com/ndgl/spotfinder/domain/post/scheduler/PostViewSyncScheduler.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/scheduler/PostViewSyncScheduler.java
@@ -1,10 +1,11 @@
 package com.ndgl.spotfinder.domain.post.scheduler;
 
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.ndgl.spotfinder.domain.post.dto.PostViewCountDto;
 import com.ndgl.spotfinder.domain.post.service.PostViewCountService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class PostViewSyncScheduler {
 
 	@Scheduled(fixedRate = POST_VIEW_COUNT_SYNC_PERIOD)
 	public void syncViews() {
-		Map<Long, Long> views = postViewCountService.collectPostViewCounts();
+		List<PostViewCountDto> views = postViewCountService.collectPostViewCounts();
 
 		if (!views.isEmpty()) {
 			postViewCountService.applyToDatabase(views);

--- a/src/main/java/com/ndgl/spotfinder/domain/post/scheduler/PostViewSyncScheduler.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/scheduler/PostViewSyncScheduler.java
@@ -9,7 +9,9 @@ import com.ndgl.spotfinder.domain.post.dto.PostViewCountDto;
 import com.ndgl.spotfinder.domain.post.service.PostViewCountService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PostViewSyncScheduler {
@@ -19,10 +21,12 @@ public class PostViewSyncScheduler {
 
 	@Scheduled(fixedRate = POST_VIEW_COUNT_SYNC_PERIOD)
 	public void syncViews() {
+		log.debug("조회 수 배치 스케줄러 작동");
 		List<PostViewCountDto> views = postViewCountService.collectPostViewCounts();
 
 		if (!views.isEmpty()) {
 			postViewCountService.applyToDatabase(views);
 		}
+		log.debug("조회 수 DB 반영 완료");
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -157,11 +157,6 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<Post> findPostByIds(List<Long> ids) {
-		return postRepository.findByIdIn(ids);
-	}
-
-	@Transactional(readOnly = true)
 	public Long getLastPostId(SliceRequest sliceRequest) {
 		if (sliceRequest.lastId() == null) {
 			return postRepository.findTopByOrderByIdDesc()

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -95,7 +95,7 @@ public class PostService {
 	public SliceResponse<PostResponseDto> getPosts(SliceRequest sliceRequest) {
 		PageRequest pageRequest = PageRequest.of(FIRST_PAGE_NUMBER, sliceRequest.size());
 		Long lastId = getLastPostId(sliceRequest);
-		Slice<Post> results = postRepository.findByIdLessThanOrderByCreatedAtDesc(lastId, pageRequest);
+		Slice<Post> results = postRepository.findByIdLessThanOrderByIdDesc(lastId, pageRequest);
 		return convertToSliceResponse(results);
 	}
 
@@ -105,7 +105,7 @@ public class PostService {
 		Long lastId = getLastPostId(sliceRequest);
 		User user = userService.findUserById(userId);
 
-		Slice<Post> results = postRepository.findByUserAndIdLessThanOrderByCreatedAtDesc(user, lastId, pageRequest);
+		Slice<Post> results = postRepository.findByUserAndIdLessThanOrderByIdDesc(user, lastId, pageRequest);
 
 		return convertToSliceResponse(results);
 	}

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostViewCountService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostViewCountService.java
@@ -1,20 +1,17 @@
 package com.ndgl.spotfinder.domain.post.service;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
-import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.KeyScanOptions;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.ndgl.spotfinder.domain.post.entity.Post;
+import com.ndgl.spotfinder.domain.post.dto.PostViewCountDto;
 import com.ndgl.spotfinder.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -22,51 +19,43 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PostViewCountService {
+	private final RedisConnectionFactory redisConnectionFactory;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final KeyScanOptions postViewCountKeyOptions;
 	private final PostService postService;
 
 	private static final String POST_KEY_PREFIX = "viewed:post:";
-	private static final long SCAN_BATCH_SIZE = 1000;
 
-	public Map<Long, Long> collectPostViewCounts() {
-		Map<Long, Long> viewCountMap = new HashMap<>();
-		RedisConnection connection = Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection();
-
-		KeyScanOptions options = (KeyScanOptions)ScanOptions
-			.scanOptions()
-			.type(DataType.SET)
-			.match(POST_KEY_PREFIX + "*")
-			.count(SCAN_BATCH_SIZE)
-			.build();
-
-		Cursor<byte[]> cursor = connection.scan(options);
+	public List<PostViewCountDto> collectPostViewCounts() {
+		List<PostViewCountDto> viewCountInfo = new ArrayList<>();
+		RedisConnection connection = redisConnectionFactory.getConnection();
+		Cursor<byte[]> cursor = connection.scan(postViewCountKeyOptions);
 
 		while (cursor.hasNext()) {
 			String key = new String(cursor.next());
 			Long postId = extractPostIdFromKey(key);
 			Long viewCount = redisTemplate.opsForSet().size(key);
 
-			viewCountMap.put(postId, viewCount);
+			viewCountInfo.add(new PostViewCountDto(postId, viewCount));
 		}
 
-		return viewCountMap;
+		return viewCountInfo;
 	}
 
 	@Transactional
-	public void applyToDatabase(Map<Long, Long> viewCounts) {
-		List<Long> postIds = viewCounts.keySet().stream().toList();
-		List<Post> posts = postService.findPostByIds(postIds);
-
-		viewCounts.forEach(postService::incrementPostViewCount);
+	public void applyToDatabase(List<PostViewCountDto> viewCounts) {
+		viewCounts.forEach(postViewCount ->
+			postService.incrementPostViewCount(postViewCount.getPostId(), postViewCount.getViewCount())
+		);
 
 		deleteFromRedis(viewCounts);
 	}
 
 	@Transactional
-	public void deleteFromRedis(Map<Long, Long> viewCounts) {
-		List<String> keys = viewCounts.keySet()
+	public void deleteFromRedis(List<PostViewCountDto> viewCounts) {
+		List<String> keys = viewCounts
 			.stream()
-			.map(this::mapPostIdToRedisKey)
+			.map(postViewCount -> mapPostIdToRedisKey(postViewCount.getPostId()))
 			.toList();
 
 		redisTemplate.delete(keys);

--- a/src/main/java/com/ndgl/spotfinder/global/common/util/MarkdownUtil.java
+++ b/src/main/java/com/ndgl/spotfinder/global/common/util/MarkdownUtil.java
@@ -1,0 +1,12 @@
+package com.ndgl.spotfinder.global.common.util;
+
+import org.jsoup.Jsoup;
+
+public final class MarkdownUtil {
+	private MarkdownUtil() {
+	}
+
+	public static String extractTextFromMarkdown(String markdownText) {
+		return Jsoup.parse(markdownText).text();
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/global/common/util/StringUtil.java
+++ b/src/main/java/com/ndgl/spotfinder/global/common/util/StringUtil.java
@@ -1,0 +1,12 @@
+package com.ndgl.spotfinder.global.common.util;
+
+public final class StringUtil {
+	private StringUtil() {
+	}
+
+	public static String removeNewLines(String input) {
+		if (input == null)
+			return null;
+		return input.replaceAll("\\r\\n|\\n|\\r", " ");
+	}
+}

--- a/src/main/java/com/ndgl/spotfinder/global/redis/RedisConfig.java
+++ b/src/main/java/com/ndgl/spotfinder/global/redis/RedisConfig.java
@@ -5,10 +5,13 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.KeyScanOptions;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -23,6 +26,9 @@ public class RedisConfig {
 
 	@Value("${spring.data.redis.port}")
 	private int redisPort;
+
+	private static final String POST_KEY_PREFIX = "viewed:post:";
+	private static final long SCAN_BATCH_SIZE = 1000;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
@@ -51,5 +57,15 @@ public class RedisConfig {
 		template.setValueSerializer(new Jackson2JsonRedisSerializer<>(List.class));
 
 		return template;
+	}
+
+	@Bean
+	public KeyScanOptions postViewCountKeyOptions() {
+		return (KeyScanOptions)ScanOptions
+			.scanOptions()
+			.type(DataType.SET)
+			.match(POST_KEY_PREFIX + "*")
+			.count(SCAN_BATCH_SIZE)
+			.build();
 	}
 }


### PR DESCRIPTION
## Issue
resolved #182
resolved #183
resolved #186
resolved #193

## 요구 사항과 구현 내용
- Redis 관련 객체들을 Bean으로 주입받도록 변경
- 포스트 조회 시 생성날짜가 아닌 ID를 기준으로 내림차순 조회하도록 수정
- 해시태그 조회 시 fetch join 대신 batch로 가져오도록 수정
- 포스트 목록에서 마크다운 및 개행을 제거한 뒤 약 200자 이내로 표시