### PR TITLE
Swagger에 API 사양서 작성 (User 도메인, Auth도메인) 

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/auth/controller/AuthApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/auth/controller/AuthApiSpecification.java
@@ -1,13 +1,12 @@
 package com.ndgl.spotfinder.domain.auth.controller;
 
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 
 import com.ndgl.spotfinder.domain.auth.dto.CheckAuthStatusResponseDto;
 import com.ndgl.spotfinder.global.rsdata.RsData;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,11 +19,10 @@ public interface AuthApiSpecification {
 		description = "로그인 된 상황에서, cookie 통해 토큰을 받으면, 토큰의 상태를 체크, 만료 된 토큰이면 갱신 처리 진행.",
 		security = {@SecurityRequirement(name = "JWT")}
 	)
-	@GetMapping("/status")
 	RsData<CheckAuthStatusResponseDto> checkAuthStatus(
 		@CookieValue(value = "accessToken", required = false) String accessToken,
 		@CookieValue(value = "refreshToken", required = false) String refreshToken,
-		HttpServletResponse response
+		@Parameter(hidden = true) HttpServletResponse response
 	);
 
 	@Operation(
@@ -32,9 +30,8 @@ public interface AuthApiSpecification {
 		description = "입력 받은 accessToken 갱신",
 		security = {@SecurityRequirement(name = "JWT")}
 	)
-	@PostMapping("/token/refresh")
 	RsData<String> refreshAccessToken(
-		HttpServletResponse response,
+		@Parameter(hidden = true) HttpServletResponse response,
 		@CookieValue(value = "accessToken", required = false) String accessToken,
 		@CookieValue(value = "refreshToken", required = false) String refreshToken
 	);

--- a/src/main/java/com/ndgl/spotfinder/domain/auth/controller/AuthApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/auth/controller/AuthApiSpecification.java
@@ -1,0 +1,42 @@
+package com.ndgl.spotfinder.domain.auth.controller;
+
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import com.ndgl.spotfinder.domain.auth.dto.CheckAuthStatusResponseDto;
+import com.ndgl.spotfinder.global.rsdata.RsData;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Tag(name = "권한(Auth)")
+public interface AuthApiSpecification {
+
+	@Operation(
+		summary = "JWT 토큰 만료시간 체크, ",
+		description = "로그인 된 상황에서, cookie 통해 토큰을 받으면, 토큰의 상태를 체크, 만료 된 토큰이면 갱신 처리 진행.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
+	@GetMapping("/status")
+	RsData<CheckAuthStatusResponseDto> checkAuthStatus(
+		@CookieValue(value = "accessToken", required = false) String accessToken,
+		@CookieValue(value = "refreshToken", required = false) String refreshToken,
+		HttpServletResponse response
+	);
+
+	@Operation(
+		summary = "JWT 토큰 갱신, ",
+		description = "입력 받은 accessToken 갱신",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
+	@PostMapping("/token/refresh")
+	RsData<String> refreshAccessToken(
+		HttpServletResponse response,
+		@CookieValue(value = "accessToken", required = false) String accessToken,
+		@CookieValue(value = "refreshToken", required = false) String refreshToken
+	);
+
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/auth/controller/AuthController.java
@@ -1,12 +1,9 @@
 package com.ndgl.spotfinder.domain.auth.controller;
 
-import java.util.Map;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
-public class AuthController {
+public class AuthController implements AuthApiSpecification {
 
 	private final AuthService authService;
 
@@ -34,18 +31,18 @@ public class AuthController {
 		@CookieValue(value = "refreshToken", required = false) String refreshToken,
 		HttpServletResponse response
 	) {
-		CheckAuthStatusResponseDto responseDto = authService.statusCheck(accessToken,refreshToken,response);
+		CheckAuthStatusResponseDto responseDto = authService.statusCheck(accessToken, refreshToken, response);
 
 		return RsData.success(HttpStatus.OK, responseDto);
 	}
 
 	@PostMapping("/token/refresh")
-	RsData<String> refreshAccessToken(
+	public RsData<String> refreshAccessToken(
 		HttpServletResponse response,
 		@CookieValue(value = "accessToken", required = false) String accessToken,
 		@CookieValue(value = "refreshToken", required = false) String refreshToken
 	) {
-		authService.refreshAccessToken(accessToken, refreshToken,response);
+		authService.refreshAccessToken(accessToken, refreshToken, response);
 
 		return RsData.success(HttpStatus.OK);
 	}

--- a/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserApiSpecification.java
@@ -1,0 +1,64 @@
+package com.ndgl.spotfinder.domain.user.controller;
+
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.ndgl.spotfinder.domain.user.dto.UserInfoResponseDto;
+import com.ndgl.spotfinder.domain.user.dto.UserJoinRequestDto;
+import com.ndgl.spotfinder.domain.user.dto.UserModifiedRequestDto;
+import com.ndgl.spotfinder.domain.user.dto.UserModifiedResponseDto;
+import com.ndgl.spotfinder.domain.user.dto.UserResignedResponseDto;
+import com.ndgl.spotfinder.global.rsdata.RsData;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+
+@Tag(name = "유저")
+public interface UserApiSpecification {
+
+	@Operation(summary = "회원 가입", description = "소셜 플랫폼을 통해 최초 로그인 진행 시 닉네임, 블로그 명을 입력하여 회원가입을 진행.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "OK")
+	})
+	@PostMapping("/join")
+	RsData<Void> join(@Valid @RequestBody UserJoinRequestDto userJoinRequestDTO);
+
+	@Operation(summary = "구글 로그인 처리", description = "구글 OAuth 인증 코드를 받아 사용자 인증을 수행합니다.")
+	@GetMapping("/google/login/process")
+	RsData<?> processGoogleLogin(
+		@Parameter(description = "f/e에서 전해주는 인증 코드") @RequestParam("code") String code,
+		@Parameter(description = "f/e에서 전해주는 redirect URI") @RequestParam("redirect_uri") String redirectUri,
+		HttpServletResponse response
+	);
+
+	@Operation(summary = "로그아웃", description = "로그아웃 처리 진행.")
+	@PostMapping("/logout")
+	RsData<Void> logout(@CookieValue(value = "accessToken", required = false) String accessToken,
+		HttpServletResponse response);
+
+	@Operation(summary = "마이페이지", description = "마이페이지를 열어 정보를 보여줌.")
+	@GetMapping("/info")
+	RsData<UserInfoResponseDto> userInfo(@CookieValue("accessToken") String accessToken);
+
+	@Operation(summary = "유저 정보 수정", description = "마이페이지를 열어 정보를 보여줌.")
+	@PutMapping
+	RsData<UserModifiedResponseDto> update(
+		@RequestBody UserModifiedRequestDto request,
+		@CookieValue("accessToken") String accessToken);
+
+	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리.")
+	@DeleteMapping("/resign")
+	RsData<UserResignedResponseDto> resign(
+		@CookieValue("accessToken") String accessToken,
+		HttpServletResponse response);
+}

--- a/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserApiSpecification.java
@@ -1,10 +1,6 @@
 package com.ndgl.spotfinder.domain.user.controller;
 
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -31,15 +27,13 @@ public interface UserApiSpecification {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "OK")
 	})
-	@PostMapping("/join")
 	RsData<Void> join(@Valid @RequestBody UserJoinRequestDto userJoinRequestDTO);
 
 	@Operation(summary = "구글 로그인 처리", description = "구글 OAuth 인증 코드를 받아 사용자 인증을 수행합니다.")
-	@GetMapping("/google/login/process")
 	RsData<?> processGoogleLogin(
 		@Parameter(description = "f/e에서 전해주는 인증 코드") @RequestParam("code") String code,
 		@Parameter(description = "f/e에서 전해주는 redirect URI") @RequestParam("redirect_uri") String redirectUri,
-		HttpServletResponse response
+		@Parameter(hidden = true) HttpServletResponse response
 	);
 
 	@Operation(
@@ -47,16 +41,15 @@ public interface UserApiSpecification {
 		description = "로그아웃 처리 진행.",
 		security = {@SecurityRequirement(name = "JWT")}
 	)
-	@PostMapping("/logout")
-	RsData<Void> logout(@CookieValue(value = "accessToken", required = false) String accessToken,
-		HttpServletResponse response);
+	RsData<Void> logout(
+		@CookieValue(value = "accessToken", required = false) String accessToken,
+		@Parameter(hidden = true) HttpServletResponse response);
 
 	@Operation(
 		summary = "마이페이지",
 		description = "마이페이지를 열어 정보를 보여줌.",
 		security = {@SecurityRequirement(name = "JWT")}
 	)
-	@GetMapping("/info")
 	RsData<UserInfoResponseDto> userInfo(@CookieValue("accessToken") String accessToken);
 
 	@Operation(
@@ -64,7 +57,6 @@ public interface UserApiSpecification {
 		description = "마이페이지를 열어 정보를 보여줌.",
 		security = {@SecurityRequirement(name = "JWT")}
 	)
-	@PutMapping
 	RsData<UserModifiedResponseDto> update(
 		@RequestBody UserModifiedRequestDto request,
 		@CookieValue("accessToken") String accessToken);
@@ -74,8 +66,7 @@ public interface UserApiSpecification {
 		description = "회원 탈퇴 처리.",
 		security = {@SecurityRequirement(name = "JWT")}
 	)
-	@DeleteMapping("/resign")
 	RsData<UserResignedResponseDto> resign(
 		@CookieValue("accessToken") String accessToken,
-		HttpServletResponse response);
+		@Parameter(hidden = true) HttpServletResponse response);
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserApiSpecification.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserApiSpecification.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -41,22 +42,38 @@ public interface UserApiSpecification {
 		HttpServletResponse response
 	);
 
-	@Operation(summary = "로그아웃", description = "로그아웃 처리 진행.")
+	@Operation(
+		summary = "로그아웃",
+		description = "로그아웃 처리 진행.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@PostMapping("/logout")
 	RsData<Void> logout(@CookieValue(value = "accessToken", required = false) String accessToken,
 		HttpServletResponse response);
 
-	@Operation(summary = "마이페이지", description = "마이페이지를 열어 정보를 보여줌.")
+	@Operation(
+		summary = "마이페이지",
+		description = "마이페이지를 열어 정보를 보여줌.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@GetMapping("/info")
 	RsData<UserInfoResponseDto> userInfo(@CookieValue("accessToken") String accessToken);
 
-	@Operation(summary = "유저 정보 수정", description = "마이페이지를 열어 정보를 보여줌.")
+	@Operation(
+		summary = "유저 정보 수정",
+		description = "마이페이지를 열어 정보를 보여줌.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@PutMapping
 	RsData<UserModifiedResponseDto> update(
 		@RequestBody UserModifiedRequestDto request,
 		@CookieValue("accessToken") String accessToken);
 
-	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리.")
+	@Operation(
+		summary = "회원 탈퇴",
+		description = "회원 탈퇴 처리.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@DeleteMapping("/resign")
 	RsData<UserResignedResponseDto> resign(
 		@CookieValue("accessToken") String accessToken,

--- a/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserController.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/controller/UserController.java
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/users")
-public class UserController {
+public class UserController implements UserApiSpecification {
 
 	private final OauthService oauthService;
 	private final TokenProvider tokenProvider;

--- a/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserInfoResponseDto.java
@@ -4,9 +4,16 @@ import java.time.LocalDateTime;
 
 import com.ndgl.spotfinder.domain.user.entity.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserInfoResponseDto(
+	@Schema(description = "유저의 닉네임.", examples = "testman001")
 	String nickname,
+
+	@Schema(description = "유저의 블로그 명.", examples = "testblog001")
 	String blogName,
+
+	@Schema(description = "유저의 이메일 정보.", examples = "testman001@test.com")
 	String email,
 	LocalDateTime createdAt
 ) {

--- a/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserJoinRequestDto.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/user/dto/UserJoinRequestDto.java
@@ -2,6 +2,7 @@ package com.ndgl.spotfinder.domain.user.dto;
 
 import com.ndgl.spotfinder.domain.user.entity.Provider;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -11,15 +12,19 @@ import lombok.Getter;
 @Getter
 @Builder
 public class UserJoinRequestDto {
+	@Schema(description = "로그인 시 받아온 소셜 플랫폼 정보.", examples = "GOOGLE")
 	@NotNull(message = "provider 값이 없습니다. ")
 	private Provider provider;
 
+	@Schema(description = "로그인 시 받아 온 소셜 플랫폼 인증 정보.", examples = "123456789")
 	@NotNull(message = "identify 값이 필요합니다.")
 	private String identify;
 
+	@Schema(description = "로그인 시 받아온 이메일 정보.", examples = "testman123@test.com")
 	@NotNull(message = "email 값이 필요합니다.")
 	private String email;
 
+	@Schema(description = "닉네임", example = "testman001")
 	@NotNull(message = "nickName 값이 필요합니다.")
 	@Size(min = 2, max = 15, message = "닉네임은 15자 이하로 입력해주세요.")
 	@Pattern(
@@ -28,6 +33,7 @@ public class UserJoinRequestDto {
 	)
 	private final String nickName;
 
+	@Schema(description = "블로그 명", example = "testblog001")
 	@NotNull(message = "blogName 값이 필요합니다.")
 	@Size(min = 2, max = 20, message = "블로그 명은 20자 이하로 입력해주세요.")
 	@Pattern(


### PR DESCRIPTION
API 사양서 작성 내용. 

- User 도메인
  -  회원 가입 
  -  로그인 처리
  -  마이페이지
  -  회원 정보 수정
  -  회원 탈퇴

- Auth도메인
  -  토큰 만료시간 체크 
  -  토큰 갱신 