### PR TITLE
PopularKeyword, PopularPost 엔티티 필드명 rank -> ranking  수정, ServiceExceptionLoggingAspect 에 CustomS3Exception 처리 로직 추가

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/popular/entity/PopularKeyword.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/popular/entity/PopularKeyword.java
@@ -28,12 +28,12 @@ public class PopularKeyword extends BaseTime {
 	private long searchCount;
 
 	@Column(nullable = false)
-	private int rank;
+	private int ranking;
 
 	@Builder
-	private PopularKeyword(String keyword, long searchCount, int rank) {
+	private PopularKeyword(String keyword, long searchCount, int ranking) {
 		this.keyword = keyword;
 		this.searchCount = searchCount;
-		this.rank = rank;
+		this.ranking = ranking;
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/popular/entity/PopularPost.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/popular/entity/PopularPost.java
@@ -28,12 +28,12 @@ public class PopularPost extends BaseTime {
 	private long viewCount;
 
 	@Column(nullable = false)
-	private int rank;
+	private int ranking;
 
 	@Builder
-	private PopularPost(long postId, long viewCount, int rank) {
+	private PopularPost(long postId, long viewCount, int ranking) {
 		this.postId = postId;
 		this.viewCount = viewCount;
-		this.rank = rank;
+		this.ranking = ranking;
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/domain/popular/service/PopularService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/popular/service/PopularService.java
@@ -31,7 +31,7 @@ public class PopularService {
 			entities.add(PopularKeyword.builder()
 				.keyword(kc.keyword())
 				.searchCount(kc.count())
-				.rank(i + 1)
+				.ranking(i + 1)
 				.build());
 		}
 
@@ -47,7 +47,7 @@ public class PopularService {
 			entities.add(PopularPost.builder()
 				.postId(pc.postId())
 				.viewCount(pc.count())
-				.rank(i + 1)
+				.ranking(i + 1)
 				.build());
 		}
 

--- a/src/main/java/com/ndgl/spotfinder/global/aspect/logging/ServiceExceptionLoggingAspect.java
+++ b/src/main/java/com/ndgl/spotfinder/global/aspect/logging/ServiceExceptionLoggingAspect.java
@@ -52,7 +52,7 @@ public class ServiceExceptionLoggingAspect {
 			statusCode = exception.getCode().value();
 			exceptionMessage = exception.getMessage();
 		} else if (ex instanceof CustomS3Exception exception) {
-			statusCode = HttpStatus.BAD_REQUEST.value();
+			statusCode = exception.getCode().value();
 			exceptionMessage = exception.getMessage();
 		} else if (ex instanceof MethodArgumentNotValidException exception) {
 			statusCode = HttpStatus.BAD_REQUEST.value();

--- a/src/main/java/com/ndgl/spotfinder/global/aspect/logging/ServiceExceptionLoggingAspect.java
+++ b/src/main/java/com/ndgl/spotfinder/global/aspect/logging/ServiceExceptionLoggingAspect.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ndgl.spotfinder.global.exception.CustomS3Exception;
 import com.ndgl.spotfinder.global.exception.ServiceException;
 import com.ndgl.spotfinder.global.logging.context.RequestLogContext;
 
@@ -49,6 +50,9 @@ public class ServiceExceptionLoggingAspect {
 
 		if (ex instanceof ServiceException exception) {
 			statusCode = exception.getCode().value();
+			exceptionMessage = exception.getMessage();
+		} else if (ex instanceof CustomS3Exception exception) {
+			statusCode = HttpStatus.BAD_REQUEST.value();
 			exceptionMessage = exception.getMessage();
 		} else if (ex instanceof MethodArgumentNotValidException exception) {
 			statusCode = HttpStatus.BAD_REQUEST.value();

--- a/src/test/java/com/ndgl/spotfinder/domain/popular/PopularServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/popular/PopularServiceTest.java
@@ -52,11 +52,11 @@ public class PopularServiceTest {
 		assertThat(saved).hasSize(2);
 		assertThat(saved.get(0).getKeyword()).isEqualTo("서울");
 		assertThat(saved.get(0).getSearchCount()).isEqualTo(100L);
-		assertThat(saved.get(0).getRank()).isEqualTo(1);
+		assertThat(saved.get(0).getRanking()).isEqualTo(1);
 
 		assertThat(saved.get(1).getKeyword()).isEqualTo("강남");
 		assertThat(saved.get(1).getSearchCount()).isEqualTo(80L);
-		assertThat(saved.get(1).getRank()).isEqualTo(2);
+		assertThat(saved.get(1).getRanking()).isEqualTo(2);
 	}
 
 	@Test
@@ -79,10 +79,10 @@ public class PopularServiceTest {
 		assertThat(saved).hasSize(2);
 		assertThat(saved.get(0).getPostId()).isEqualTo(1L);
 		assertThat(saved.get(0).getViewCount()).isEqualTo(100L);
-		assertThat(saved.get(0).getRank()).isEqualTo(1);
+		assertThat(saved.get(0).getRanking()).isEqualTo(1);
 
 		assertThat(saved.get(1).getPostId()).isEqualTo(2L);
 		assertThat(saved.get(1).getViewCount()).isEqualTo(80L);
-		assertThat(saved.get(1).getRank()).isEqualTo(2);
+		assertThat(saved.get(1).getRanking()).isEqualTo(2);
 	}
 }


### PR DESCRIPTION
1.  PopularKeyword, PopularPost 엔티티 MySQL 예약어 충돌로 인해 rank -> ranking 으로 수정
2. ServiceExceptionLoggingAspect 에서 CustomS3Exception 도 처리하도록 추가