### PR TITLE
POST 검색시 Public Status만 조회, 섬네일 이미지 변경 및 제거 시 리소스 제거 로직 추가 

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/domain/image/service/ImageCleanupService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/image/service/ImageCleanupService.java
@@ -1,5 +1,6 @@
 package com.ndgl.spotfinder.domain.image.service;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -7,6 +8,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.ndgl.spotfinder.domain.image.entity.Image;
 import com.ndgl.spotfinder.domain.image.repository.ImageRepository;
@@ -27,32 +29,43 @@ public class ImageCleanupService {
 	/**
 	 * 포스트 내용에서 사용되지 않는 이미지를 비동기적으로 삭제
 	 *
-	 * @param imageUsage     이미지 타입 (POST 등)
-	 * @param referenceId   참조 ID (포스트 ID 등)
-	 * @param usedImageUrls 컨텐츠에서 실제 사용 중인 이미지 URL 목록
+	 * @param imageUsage       이미지 타입 (POST 등)
+	 * @param referenceId      참조 ID (포스트 ID 등)
+	 * @param usedImageUrls    컨텐츠에서 실제 사용 중인 이미지 URL 목록
+	 * @param currentThumbnail 현재 포스트의 썸네일 URL
 	 */
 	@Async("imageCleanupExecutor")
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void cleanupUnusedImages(ImageUsage imageUsage, long referenceId, Set<String> usedImageUrls) {
+	public void cleanupUnusedImages(
+		ImageUsage imageUsage,
+		long referenceId,
+		Set<String> usedImageUrls,
+		String currentThumbnail
+	) {
+		Set<String> allUsedImages = new HashSet<>(usedImageUrls);
+		if (StringUtils.hasText(currentThumbnail)) {
+			allUsedImages.add(currentThumbnail);
+		}
+
 		try {
 			List<Image> savedImages = imageRepository.findByImageUsageAndReferenceId(imageUsage, referenceId);
 
-			List<Image> unusedImages = savedImages.stream()
-				.filter(image -> !usedImageUrls.contains(image.getUrl()))
-				.toList();
+			savedImages.stream()
+				.filter(image -> !allUsedImages.contains(image.getUrl()))
+				.forEach(image -> {
+					try {
+						s3Service.deleteFile(image.getUrl());
+						imageRepository.delete(image);
+					} catch (Exception e) {
+						log.error("이미지 삭제 중 오류 발생: {}", image.getUrl(), e);
+					}
+				});
 
-			// 미사용 이미지 삭제 (S3 및 DB에서)
-			for (Image image : unusedImages) {
-				try {
-					s3Service.deleteFile(image.getUrl());
-					imageRepository.delete(image);
-				} catch (Exception e) {
-					log.error("삭제 중 실패 이미지 {}: {}", image.getUrl(), e.getMessage());
-				}
-			}
+			log.debug("이미지 정리 완료: imageUsage={}, referenceId={}, 이미지 수: {}",
+				imageUsage, referenceId, savedImages.size());
 		} catch (Exception e) {
-			// 비동기 메서드에서는 예외를 던지지 않고 로깅만 처리
-			log.error("비동기 이미지 정리 에러 : {}", e.getMessage(), e);
+			log.error("이미지 정리 중 예외 발생: imageUsage={}, referenceId={}", imageUsage, referenceId, e);
 		}
 	}
+
 } 

--- a/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/repository/PostRepository.java
@@ -16,22 +16,31 @@ import com.ndgl.spotfinder.domain.post.entity.PostStatus;
 import com.ndgl.spotfinder.domain.user.entity.User;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-	Slice<Post> findByIdLessThanOrderByIdDesc(Long lastId, PageRequest pageRequest);
+	Slice<Post> findByStatusAndIdLessThanOrderByIdDesc(
+		PostStatus status, Long lastId, PageRequest pageRequest);
 
-	Slice<Post> findByUserAndIdLessThanOrderByIdDesc(User user, Long lastId, PageRequest pageRequest);
+	Slice<Post> findByStatusAndUserAndIdLessThanOrderByIdDesc(
+		PostStatus status, User user, Long lastId, PageRequest pageRequest);
 
 	@Query("SELECT p FROM Post p " +
-		   "JOIN Like l ON p.id = l.targetId AND l.targetType = 'POST' " +
-		   "WHERE l.user.id = :userId AND p.id < :lastId " +
-		   "ORDER BY p.id DESC")
-	Slice<Post> findLikedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
+		"JOIN Like l ON p.id = l.targetId AND l.targetType = 'POST' " +
+		"WHERE l.user.id = :userId AND p.id < :lastId AND p.status = :postStatus " +
+		"ORDER BY p.id DESC")
+	Slice<Post> findLikedPostsByUser(
+		@Param("userId") Long userId,
+		@Param("lastId") Long lastId,
+		@Param("postStatus") PostStatus postStatus,
 		PageRequest pageRequest);
 
 	@Query("SELECT p FROM Post p " +
-		   "JOIN Follow f ON f.follower.id = :userId AND f.followee.id = p.user.id " +
-		   "WHERE p.id < :lastId " +
-		   "ORDER BY p.id DESC")
-	Slice<Post> findFollowedPostsByUser(@Param("userId") Long userId, @Param("lastId") Long lastId,
+		"JOIN Follow f ON f.follower.id = :userId AND f.followee.id = p.user.id " +
+		"WHERE p.id < :lastId " +
+		"AND p.status = :postStatus " +
+		"ORDER BY p.id DESC")
+	Slice<Post> findFollowedPostsByUser(
+		@Param("userId") Long userId,
+		@Param("lastId") Long lastId,
+		@Param("postStatus") PostStatus postStatus,
 		PageRequest pageRequest);
 
 	Optional<Post> findTopByOrderByIdDesc();
@@ -39,24 +48,39 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	Optional<Post> findFirstByUserAndStatus(User user, PostStatus status);
 
 	@Query("SELECT p FROM Post p "
-		   + "WHERE (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-		   + "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-		   + "OR LOWER(p.user.nickName) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-		   + "OR EXISTS (SELECT h FROM p.hashtags h WHERE LOWER(h.name) LIKE LOWER(CONCAT('%', :keyword, '%')))) "
-		   + "ORDER BY p.id DESC")
+		+ "WHERE (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		+ "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		+ "OR LOWER(p.user.nickName) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+		+ "OR EXISTS (SELECT h FROM p.hashtags h WHERE LOWER(h.name) LIKE LOWER(CONCAT('%', :keyword, '%')))) "
+		+ "AND p.status = 'PUBLIC'"
+		+ "ORDER BY p.id DESC")
 	Slice<Post> searchAll(String keyword, PageRequest pageRequest);
 
 	List<Post> findByUser(User user);
 
 	@Query("SELECT DISTINCT p FROM Post p "
-		   + "JOIN FETCH p.user "
-		   + "LEFT JOIN FETCH p.hashtags")
+		+ "JOIN FETCH p.user "
+		+ "LEFT JOIN FETCH p.hashtags "
+		+ "WHERE p.status = 'PUBLIC'")
 	List<Post> findAllWithAssociations();
 
 	@Query("SELECT DISTINCT p FROM Post p "
-		   + "JOIN FETCH p.user LEFT JOIN FETCH p.hashtags "
-		   + "WHERE p.updatedAt > :updatedAt")
+		+ "JOIN FETCH p.user "
+		+ "LEFT JOIN FETCH p.hashtags "
+		+ "WHERE p.status = :status")
+	List<Post> findAllWithAssociations(@Param("status") PostStatus status);
+
+	@Query("SELECT DISTINCT p FROM Post p "
+		+ "JOIN FETCH p.user LEFT JOIN FETCH p.hashtags "
+		+ "WHERE p.updatedAt > :updatedAt "
+		+ "AND p.status = 'PUBLIC'")
 	List<Post> findByUpdatedAtAfter(LocalDateTime updatedAt);
+
+	@Query("SELECT DISTINCT p FROM Post p "
+		+ "JOIN FETCH p.user LEFT JOIN FETCH p.hashtags "
+		+ "WHERE p.updatedAt > :updatedAt "
+		+ "AND p.status = :status")
+	List<Post> findByUpdatedAtAfter(@Param("status") PostStatus status, LocalDateTime updatedAt);
 
 	@Modifying
 	@Query("UPDATE Post p SET p.viewCount = p.viewCount + :count WHERE p.id = :postId")

--- a/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
+++ b/src/main/java/com/ndgl/spotfinder/domain/post/service/PostService.java
@@ -78,7 +78,6 @@ public class PostService {
 
 		checkUserPermission(post, email);
 		postRepository.save(requestDto.toUpdatedPost(post, postStatus));
-
 		cleanupImages(post);
 	}
 
@@ -95,7 +94,8 @@ public class PostService {
 	public SliceResponse<PostResponseDto> getPosts(SliceRequest sliceRequest) {
 		PageRequest pageRequest = PageRequest.of(FIRST_PAGE_NUMBER, sliceRequest.size());
 		Long lastId = getLastPostId(sliceRequest);
-		Slice<Post> results = postRepository.findByIdLessThanOrderByIdDesc(lastId, pageRequest);
+		Slice<Post> results = postRepository.findByStatusAndIdLessThanOrderByIdDesc(
+			PostStatus.PUBLIC, lastId, pageRequest);
 		return convertToSliceResponse(results);
 	}
 
@@ -105,7 +105,9 @@ public class PostService {
 		Long lastId = getLastPostId(sliceRequest);
 		User user = userService.findUserById(userId);
 
-		Slice<Post> results = postRepository.findByUserAndIdLessThanOrderByIdDesc(user, lastId, pageRequest);
+		Slice<Post> results = postRepository.findByStatusAndUserAndIdLessThanOrderByIdDesc(
+			PostStatus.PUBLIC, user, lastId, pageRequest
+		);
 
 		return convertToSliceResponse(results);
 	}
@@ -134,7 +136,8 @@ public class PostService {
 		Long lastId = getLastPostId(sliceRequest);
 		User user = userService.findUserByEmail(email);
 
-		Slice<Post> results = postRepository.findLikedPostsByUser(user.getId(), lastId, pageRequest);
+		Slice<Post> results = postRepository.findLikedPostsByUser(
+			user.getId(), lastId, PostStatus.PUBLIC, pageRequest);
 
 		return convertToSliceResponse(results);
 	}
@@ -145,7 +148,9 @@ public class PostService {
 		Long lastId = getLastPostId(sliceRequest);
 		User user = userService.findUserByEmail(email);
 
-		Slice<Post> results = postRepository.findFollowedPostsByUser(user.getId(), lastId, pageRequest);
+		Slice<Post> results = postRepository.findFollowedPostsByUser(
+			user.getId(), lastId, PostStatus.PUBLIC, pageRequest
+		);
 
 		return convertToSliceResponse(results);
 	}
@@ -180,7 +185,7 @@ public class PostService {
 
 	private void cleanupImages(Post post) {
 		Set<String> usedImageUrls = extractImageUrlsFromContent(post.getContent());
-		imageCleanupService.cleanupUnusedImages(ImageUsage.POST, post.getId(), usedImageUrls);
+		imageCleanupService.cleanupUnusedImages(ImageUsage.POST, post.getId(), usedImageUrls, post.getThumbnail());
 	}
 
 	private SliceResponse<PostResponseDto> convertToSliceResponse(Slice<Post> results) {

--- a/src/main/java/com/ndgl/spotfinder/global/async/AsyncConfig.java
+++ b/src/main/java/com/ndgl/spotfinder/global/async/AsyncConfig.java
@@ -14,11 +14,11 @@ public class AsyncConfig {
 	@Bean(name = "imageCleanupExecutor")
 	public Executor imageCleanupExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(2);
-		executor.setMaxPoolSize(5);
-		executor.setQueueCapacity(10);
-		executor.setThreadNamePrefix("ImageClean-");
-		executor.initialize();
+		executor.setCorePoolSize(2);					// 기본 스레드 수
+		executor.setMaxPoolSize(5);						// 확장 가능 최대 스레드 갯수
+		executor.setQueueCapacity(10);					// 대기 최대 보관 갯수
+		executor.setThreadNamePrefix("ImageClean-");	// 접두어
+		executor.initialize();							// 빈 생성 시 스레드 풀 초기화
 		return executor;
 	}
 }

--- a/src/main/java/com/ndgl/spotfinder/global/aws/s3/S3Service.java
+++ b/src/main/java/com/ndgl/spotfinder/global/aws/s3/S3Service.java
@@ -9,8 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.ndgl.spotfinder.domain.image.type.ImageUsage;
-import com.ndgl.spotfinder.global.exception.ErrorCode;
 import com.ndgl.spotfinder.global.common.util.CommonUtil;
+import com.ndgl.spotfinder.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +41,7 @@ public class S3Service {
 	/**
 	 * 여러 파일에 대한 업로드용 Presigned URL 목록 생성
 	 *
-	 * @param imageUsage      이미지 유형
+	 * @param imageUsage     이미지 유형
 	 * @param id             이미지와 연관된 객체 ID
 	 * @param fileExtensions 파일 확장자 목록 (jpg, png 등)
 	 * @return 생성된 Presigned URL 목록
@@ -62,7 +62,7 @@ public class S3Service {
 	/**
 	 * 단일 파일에 대한 업로드용 Presigned URL 생성
 	 *
-	 * @param imageUsage     이미지 유형 (POST, PROFILE 등)
+	 * @param imageUsage    이미지 유형 (POST, PROFILE 등)
 	 * @param id            이미지와 연관된 객체 ID (게시글 ID 등)
 	 * @param fileExtension 파일 확장자 (jpg, png 등)
 	 * @return 생성된 Presigned URL
@@ -77,36 +77,11 @@ public class S3Service {
 					.key(key))
 				.signatureDuration(Duration.ofMinutes(EXPIRATION_MINUTES)));
 
-			log.debug("Presigned URL 생성");
 			return presignedRequest.url();
 		} catch (SdkException e) {
 			throw ErrorCode.S3_PRESIGNED_GENERATION_FAIL.throwCustomS3Exception(e);
 		}
 	}
-
-	/**
-	 * 조회용 Presigned URL 생성
-	 *
-	 * @param imageUrl 원본 S3 이미지 URL
-	 * @return 지정된 시간 동안 유효한 조회용 서명된 URL
-	 */
-	// @Deprecated
-	// public URL generatePresignedGetUrl(String imageUrl) {
-	// 	try {
-	// 		String objectKey = S3Util.extractObjectKeyFromUrl(imageUrl);
-	//
-	// 		GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-	// 			.getObjectRequest(getObjectRequest -> getObjectRequest
-	// 				.bucket(bucketName)
-	// 				.key(objectKey))
-	// 			.signatureDuration(Duration.ofMinutes(EXPIRATION_MINUTES))
-	// 			.build();
-	//
-	// 		return s3Presigner.presignGetObject(presignRequest).url();
-	// 	} catch (SdkException e) {
-	// 		throw ErrorCode.S3_PRESIGNED_GENERATION_FAIL.throwS3Exception(e);
-	// 	}
-	// }
 
 	/**
 	 * 단일 S3 객체 삭제
@@ -123,7 +98,7 @@ public class S3Service {
 				.build();
 
 			s3Client.deleteObject(deleteRequest);
-			log.debug("S3 파일 삭제 완료: {}", objectKey);
+			// log.debug("S3 파일 삭제 완료: {}", objectKey);
 		} catch (SdkException e) {
 			throw ErrorCode.S3_OBJECT_DELETE_FAIL.throwCustomS3Exception(e);
 		}
@@ -161,7 +136,7 @@ public class S3Service {
 	 * S3의 폴더의 모든 Object 들 삭제
 	 *
 	 * @param imageUsage 타입
-	 * @param id        ID
+	 * @param id         ID
 	 */
 	public void deleteAllObjectsById(ImageUsage imageUsage, long id) {
 		// folderPath 로 변환

--- a/src/test/java/com/ndgl/spotfinder/domain/image/service/ImageCleanupServiceTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/image/service/ImageCleanupServiceTest.java
@@ -74,54 +74,6 @@ public class ImageCleanupServiceTest {
 	}
 
 	@Test
-	public void testAsyncImageCleanupExecution() {
-		// Given
-		ImageUsage imageUsage = ImageUsage.POST;
-		long referenceId = 100L;
-
-		// 사용 중인 이미지 URL (image1만 사용 중)
-		Set<String> usedImageUrls = new HashSet<>();
-		usedImageUrls.add("https://example.com/image1.jpg");
-
-		// 스레드 이름 확인용 변수
-		final AtomicBoolean asyncExecuted = new AtomicBoolean(false); // 비동기 작업 실행 여부
-		final String[] asyncThreadName = new String[1];
-
-		// S3 서비스 모의 설정
-		doAnswer(invocation -> {
-			asyncThreadName[0] = Thread.currentThread().getName();
-			asyncExecuted.set(true);
-			return null;
-		}).when(s3Service).deleteFile(anyString());
-
-		// When
-		System.out.println("메인 스레드: " + Thread.currentThread().getName());
-		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls);
-		System.out.println("비동기 메서드 호출 직후 - 메인 스레드는 계속 진행");
-
-		// Then
-		// 1. 비동기 메서드가 다른 스레드에서 실행되는지 확인
-		await().atMost(5, TimeUnit.SECONDS).untilTrue(asyncExecuted);
-
-		// 2. 다른 스레드에서 실행되었는지 확인
-		System.out.println("비동기 스레드: " + asyncThreadName[0]);
-		assertTrue(asyncThreadName[0].startsWith("ImageClean-"));
-
-		// 3. 적절한 이미지가 삭제되었는지 확인
-		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-			verify(s3Service, times(2)).deleteFile(anyString());
-			verify(imageRepository, times(2)).delete(imageCaptor.capture());
-
-			List<Image> deletedImages = imageCaptor.getAllValues();
-			assertEquals(2, deletedImages.size());
-			assertTrue(deletedImages.stream()
-				.anyMatch(img -> img.getUrl().equals("https://example.com/image2.jpg")));
-			assertTrue(deletedImages.stream()
-				.anyMatch(img -> img.getUrl().equals("https://example.com/image3.jpg")));
-		});
-	}
-
-	@Test
 	public void testAsyncImageCleanupWithException() {
 		// Given
 		ImageUsage imageUsage = ImageUsage.POST;
@@ -132,12 +84,135 @@ public class ImageCleanupServiceTest {
 		doThrow(new RuntimeException("S3 오류 시뮬레이션")).when(s3Service).deleteFile(anyString());
 
 		// When (예외가 발생해도 비동기 메서드는 예외를 잡아서 처리)
-		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls);
+		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls, null);
 
 		// Then (메인 스레드는 계속 진행되고, 예외는 로그만 남김)
 		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
 			verify(s3Service, times(3)).deleteFile(anyString());
 			// 예외가 발생해도 테스트 실패하지 않음
+		});
+	}
+
+	@Test
+	public void testCleanupUnusedImages() {
+		// Given
+		ImageUsage imageUsage = ImageUsage.POST;
+		long referenceId = 100L;
+		
+		// 사용 중인 이미지가 없음 (content에 이미지 없음)
+		Set<String> usedImageUrls = new HashSet<>();
+		
+		// 썸네일은 image2.jpg로 설정
+		String thumbnailUrl = "https://example.com/image2.jpg";
+		
+		final AtomicBoolean asyncExecuted = new AtomicBoolean(false);
+		
+		doAnswer(invocation -> {
+			asyncExecuted.set(true);
+			return null;
+		}).when(s3Service).deleteFile(anyString());
+		
+		// When
+		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls, thumbnailUrl);
+		
+		// Then
+		await().atMost(5, TimeUnit.SECONDS).untilTrue(asyncExecuted);
+		
+		// 썸네일(image2.jpg)은 삭제되지 않고, 나머지 이미지(image1.jpg, image3.jpg)만 삭제되어야 함
+		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+			verify(s3Service, times(2)).deleteFile(anyString());
+			verify(imageRepository, times(2)).delete(imageCaptor.capture());
+			
+			List<Image> deletedImages = imageCaptor.getAllValues();
+			assertEquals(2, deletedImages.size());
+			
+			// 썸네일을 제외한 이미지만 삭제되었는지 확인
+			assertTrue(deletedImages.stream()
+				.anyMatch(img -> img.getUrl().equals("https://example.com/image1.jpg")));
+			assertTrue(deletedImages.stream()
+				.anyMatch(img -> img.getUrl().equals("https://example.com/image3.jpg")));
+			
+			// 썸네일은 삭제되지 않았는지 확인
+			assertFalse(deletedImages.stream()
+				.anyMatch(img -> img.getUrl().equals("https://example.com/image2.jpg")));
+		});
+	}
+
+	@Test
+	public void testCleanupUnusedImagesWithNullThumbnail() {
+		// Given
+		ImageUsage imageUsage = ImageUsage.POST;
+		long referenceId = 100L;
+		
+		// 사용 중인 이미지 - image1만 컨텐츠에서 사용 중
+		Set<String> usedImageUrls = new HashSet<>();
+		usedImageUrls.add("https://example.com/image1.jpg");
+		
+		// 썸네일이 null인 경우 (설정되지 않은 경우)
+		String thumbnailUrl = null;
+		
+		final AtomicBoolean asyncExecuted = new AtomicBoolean(false);
+		
+		doAnswer(invocation -> {
+			asyncExecuted.set(true);
+			return null;
+		}).when(s3Service).deleteFile(anyString());
+		
+		// When
+		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls, thumbnailUrl);
+		
+		// Then
+		await().atMost(5, TimeUnit.SECONDS).untilTrue(asyncExecuted);
+		
+		// image1만 보존되고 나머지는 삭제되어야 함
+		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+			verify(s3Service, times(2)).deleteFile(anyString());
+			verify(imageRepository, times(2)).delete(imageCaptor.capture());
+			
+			List<Image> deletedImages = imageCaptor.getAllValues();
+			assertEquals(2, deletedImages.size());
+			
+			// 사용 중인 이미지(image1)를 제외한 이미지만 삭제되었는지 확인
+			assertTrue(deletedImages.stream()
+				.anyMatch(img -> img.getUrl().equals("https://example.com/image2.jpg")));
+			assertTrue(deletedImages.stream()
+				.anyMatch(img -> img.getUrl().equals("https://example.com/image3.jpg")));
+		});
+	}
+
+	@Test
+	public void testCleanupUnusedImagesWithContentAndThumbnail() {
+		// Given
+		ImageUsage imageUsage = ImageUsage.POST;
+		long referenceId = 100L;
+		
+		// 사용 중인 이미지 - image1은 컨텐츠에서 사용 중
+		Set<String> usedImageUrls = new HashSet<>();
+		usedImageUrls.add("https://example.com/image1.jpg");
+		
+		// 썸네일은 image3으로 설정
+		String thumbnailUrl = "https://example.com/image3.jpg";
+		
+		final AtomicBoolean asyncExecuted = new AtomicBoolean(false);
+		
+		doAnswer(invocation -> {
+			asyncExecuted.set(true);
+			return null;
+		}).when(s3Service).deleteFile(anyString());
+		
+		// When
+		imageCleanupService.cleanupUnusedImages(imageUsage, referenceId, usedImageUrls, thumbnailUrl);
+		
+		// Then
+		await().atMost(5, TimeUnit.SECONDS).untilTrue(asyncExecuted);
+		
+		// image1(컨텐츠), image3(썸네일)은 보존되고 image2만 삭제되어야 함
+		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+			verify(s3Service, times(1)).deleteFile(anyString());
+			verify(imageRepository, times(1)).delete(imageCaptor.capture());
+			
+			Image deletedImage = imageCaptor.getValue();
+			assertEquals("https://example.com/image2.jpg", deletedImage.getUrl());
 		});
 	}
 } 


### PR DESCRIPTION
## Issue

resolved #201
resolved #205

## 변경 사항 

- POST 관련 조회 시 전체 조회에서 Public Post만 조회가 가능하도록 PostRepository에서 조건을 추가했습니다.
- content내 이미지뿐만 아니라, Post의 썸네일이 변경되도 S3 및 DB 리소스에도 같이 정리 되도록 수정했습니다.