### PR TITLE
UserControllerTest.java 테스트 양식 통일, 실패 케이스 추가 

### DIFF
--- a/src/test/java/com/ndgl/spotfinder/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/user/controller/UserControllerTest.java
@@ -19,7 +19,7 @@ import com.ndgl.spotfinder.domain.user.type.Provider;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class UserControllerTest {
+class UserControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/com/ndgl/spotfinder/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ndgl/spotfinder/domain/user/controller/UserControllerTest.java
@@ -5,19 +5,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ndgl.spotfinder.domain.user.dto.UserJoinRequestDto;
-import com.ndgl.spotfinder.domain.user.service.OauthService;
 import com.ndgl.spotfinder.domain.user.type.Provider;
 
 @SpringBootTest
@@ -31,21 +27,15 @@ public class UserControllerTest {
 	@Autowired
 	private ObjectMapper objectMapper;
 
-	@InjectMocks
-	private OauthService oauthService;
-
-	@Mock
-	private RestTemplate restTemplate;
-
 	@Test
-	@DisplayName("회원가입 테스트")
+	@DisplayName("회원가입 성공 테스트")
 	void join_success() throws Exception {
 		UserJoinRequestDto request = UserJoinRequestDto.builder()
 			.provider(Provider.GOOGLE)
-			.identify("123456789")
-			.email("testman001@gmail.com")
-			.nickName("testman001")
-			.blogName("testblog001")
+			.identify("123456790")
+			.email("testman004@gmail.com")
+			.nickName("testman004")
+			.blogName("testblog004")
 			.build();
 
 		mockMvc.perform(post("/api/v1/users/join")
@@ -54,5 +44,81 @@ public class UserControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value(200))
 			.andExpect(jsonPath("$.message").value("OK"));
+	}
+
+	@Test
+	@DisplayName("회원가입 실패 테스트 - 동일 닉네임")
+	void join_sameNickname_fail() throws Exception {
+		UserJoinRequestDto request = UserJoinRequestDto.builder()
+			.provider(Provider.GOOGLE)
+			.identify("123456791")
+			.email("testman005@gmail.com")
+			.nickName("testman004")
+			.blogName("testblog005")
+			.build();
+
+		mockMvc.perform(post("/api/v1/users/join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value(409))
+			.andExpect(jsonPath("$.message").value("이미 사용중인 닉네임 입니다."));
+	}
+
+	@Test
+	@DisplayName("회원가입 실패 테스트 - 동일 블로그 명")
+	void join_sameBlogName_fail() throws Exception {
+		UserJoinRequestDto request = UserJoinRequestDto.builder()
+			.provider(Provider.GOOGLE)
+			.identify("123456792")
+			.email("testman006@gmail.com")
+			.nickName("testman005")
+			.blogName("testblog004")
+			.build();
+
+		mockMvc.perform(post("/api/v1/users/join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value(409))
+			.andExpect(jsonPath("$.message").value("이미 사용중인 블로그 명 입니다."));
+	}
+
+	@Test
+	@DisplayName("회원가입 실패 테스트 - 닉네임 공백")
+	void join_blankNickName_fail() throws Exception {
+		UserJoinRequestDto request = UserJoinRequestDto.builder()
+			.provider(Provider.GOOGLE)
+			.identify("123456793")
+			.email("testman007@gmail.com")
+			.nickName(null)
+			.blogName("testblog005")
+			.build();
+
+		mockMvc.perform(post("/api/v1/users/join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(400))
+			.andExpect(jsonPath("$.message").value("nickName 값이 필요합니다."));
+	}
+
+	@Test
+	@DisplayName("회원가입 실패 테스트 - 블로그 명 공백")
+	void join_blankBlogName_fail() throws Exception {
+		UserJoinRequestDto request = UserJoinRequestDto.builder()
+			.provider(Provider.GOOGLE)
+			.identify("123456794")
+			.email("testman008@gmail.com")
+			.nickName("testman005")
+			.blogName(null)
+			.build();
+
+		mockMvc.perform(post("/api/v1/users/join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(400))
+			.andExpect(jsonPath("$.message").value("blogName 값이 필요합니다."));
 	}
 }


### PR DESCRIPTION
양식 통일 
  -  class 명에 public 제거 
  -  join_success 및 join_sameNickName 같이 규칙에 맞게 수정 

테스트 케이스 추가 
  -  실패(이미 이용중인 닉네임 입력 시)
  -  실패(이미 이용중인 블로그 명 입력 시)
  -  실패(닉네임이 Null일 때)
  -  실패(블로그 명이 Null일 때) 