### PR TITLE
로그인 안되는 문제 해결. 

### DIFF
--- a/src/main/java/com/ndgl/spotfinder/global/security/cookie/TokenCookieUtil.java
+++ b/src/main/java/com/ndgl/spotfinder/global/security/cookie/TokenCookieUtil.java
@@ -102,7 +102,7 @@ public class TokenCookieUtil {
 			.append(sb)
 			.append("; Path=/")
 			.append(domain)
-			.append(" HttpOnly")
+			.append("; HttpOnly")
 			.append(secure)
 			.append("; SameSite=").append(sameSite)
 			.toString();


### PR DESCRIPTION
String.format ==> StringBuilder 구문 바꾸는 도중 ';' 누락 발견.

기존의 

		String accessCookie = String.format(
			"accessToken=%s; Max-Age=%d; Path=/;%s HttpOnly%s; SameSite=%s",
			accessToken,
			maxAge,
			domainInCookie,
			secureFlag,
			sameSite
		);

구문을 

		return new StringBuilder()
			.append(cookieName).append("=").append(cookieValue)
			.append(sb)
			.append("; Path=/")
			.append(domain)
			.append("; HttpOnly")
			.append(secure)
			.append("; SameSite=").append(sameSite)
			.toString();
	}

로 변경 중 

			.append("; HttpOnly") 에서 ';' 가 누락 된 			.append(" HttpOnly")형태로 들어가 있다보니 Cookie 생성에 있어 NG 발생. 

현재 해당 내용 반영 후 테스트 완료 